### PR TITLE
Fixed data race in messenger.Start() and messenger.Send()

### DIFF
--- a/messenger/http_transporter_test.go
+++ b/messenger/http_transporter_test.go
@@ -75,6 +75,8 @@ func TestTransporterStartAndSend(t *testing.T) {
 			ctrl <- true
 		}()
 	})
+	err = receiver.Listen()
+	assert.NoError(t, err)
 
 	go func() {
 		err = receiver.Start()
@@ -114,6 +116,8 @@ func TestTransporterStartAndRcvd(t *testing.T) {
 	assert.NoError(t, err)
 	receiver := NewHTTPTransporter(rcvPid)
 	receiver.Install(msgName)
+	err = receiver.Listen()
+	assert.NoError(t, err)
 
 	go func() {
 		msg := receiver.Recv()
@@ -155,6 +159,8 @@ func TestTransporterStartAndStop(t *testing.T) {
 	rcvPid, err := upid.Parse(fmt.Sprintf("%s@%s", serverId, serverAddr))
 	assert.NoError(t, err)
 	receiver := NewHTTPTransporter(rcvPid)
+	err = receiver.Listen()
+	assert.NoError(t, err)
 
 	go func() {
 		err = receiver.Start()

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -117,6 +117,12 @@ func (m *MesosMessenger) Send(upid *upid.UPID, msg proto.Message) error {
 
 // Start starts the messenger.
 func (m *MesosMessenger) Start() error {
+	if err := m.tr.Listen(); err != nil {
+		log.Errorf("Failed to start messenger: %v\n", err)
+		return err
+	}
+	m.upid = m.tr.UPID()
+
 	m.stop = make(chan struct{})
 	errChan := make(chan error)
 	go func() {
@@ -130,8 +136,6 @@ func (m *MesosMessenger) Start() error {
 		return err
 	case <-time.After(preparePeriod):
 	}
-
-	m.upid = m.tr.UPID()
 	for i := 0; i < sendRoutines; i++ {
 		go m.sendLoop()
 	}

--- a/messenger/transporter.go
+++ b/messenger/transporter.go
@@ -25,6 +25,7 @@ import (
 // Transporter defines the interfaces that should be implemented.
 type Transporter interface {
 	Send(msg *Message) error
+	Listen() error
 	Recv() *Message
 	Install(messageName string)
 	Start() error


### PR DESCRIPTION
Move the listening logic into transporter.Listen(). So that
we can make sure that messenger.Send() is called only after
the tranporter.upid is ready.

Passed go test -v -race.
