### PR TITLE
Credential support, Status for driver life-cycle funcs

### DIFF
--- a/mesos/c-api.hpp
+++ b/mesos/c-api.hpp
@@ -132,7 +132,8 @@ SchedulerPtrPair scheduler_init(
     SchedulerCallbacks* callbacks,
     void* payload,
     ProtobufObj* framework,
-    const char* master);
+    const char* master,
+    ProtobufObj* credobj);
 
 void scheduler_destroy(void* driver, void* scheduler);
 

--- a/mesos/scheduler.go
+++ b/mesos/scheduler.go
@@ -49,9 +49,7 @@ import "C"
 import (
 	"encoding/binary"
 	"errors"
-	//"log"
 	"reflect"
-	"runtime"
 	"unsafe"
 
 	"code.google.com/p/goprotobuf/proto"
@@ -86,11 +84,11 @@ type Scheduler interface {
 // ScheduerDriver defines the interfaces that needed to be implemented.
 type SchedulerDriver interface {
 	Init() error
-	Start() error
-	Stop(bool) error
-	Abort() error
-	Join() error
-	Run() error
+	Start() (Status,error)
+	Stop(bool) (Status,error)
+	Abort() (Status,error)
+	Join() (Status,error)
+	Run() (Status,error)
 	RequestResources([]*Request) error
 	LaunchTasks(*OfferID, []*TaskInfo, *Filters) error
 	KillTask(*TaskID) error
@@ -110,7 +108,12 @@ type MesosSchedulerDriver struct {
 	callbacks C.SchedulerCallbacks
 	driver    unsafe.Pointer
 	scheduler unsafe.Pointer
+	Cred      *Credential
 }
+
+var (
+	ErrSchedulerNotInitialized = errors.New("Scheduler driver not initialized")
+)
 
 func serialize(pb proto.Message) (C.ProtobufObj, error) {
 	var dataObj C.ProtobufObj
@@ -150,13 +153,23 @@ func (sdriver *MesosSchedulerDriver) Init() error {
 		return err
 	}
 
+	var credObj *C.ProtobufObj
+	if sdriver.Cred != nil {
+		if c, err := serialize(sdriver.Cred); err != nil {
+			return err
+		} else {
+			credObj = &c
+		}
+	}
+
 	sdriver.callbacks = C.getSchedulerCallbacks()
 
 	pair := C.scheduler_init(
 		&sdriver.callbacks,
 		unsafe.Pointer(sdriver),
 		&dataObj,
-		cmsg)
+		cmsg,
+		credObj)
 
 	sdriver.driver = pair.driver
 	sdriver.scheduler = pair.scheduler
@@ -164,54 +177,54 @@ func (sdriver *MesosSchedulerDriver) Init() error {
 	return nil
 }
 
-func (sdriver *MesosSchedulerDriver) Start() error {
+func (sdriver *MesosSchedulerDriver) Start() (st Status, err error) {
 	if sdriver.driver != nil {
-		C.scheduler_start(C.SchedulerDriverPtr(sdriver.driver))
+		st = Status(C.scheduler_start(C.SchedulerDriverPtr(sdriver.driver)))
 	} else {
-		return errors.New("Start() failed: scheduler driver not initialized")
+		err = ErrSchedulerNotInitialized
 	}
-	return nil
+	return
 }
 
-func (sdriver *MesosSchedulerDriver) Stop(failover bool) error {
+func (sdriver *MesosSchedulerDriver) Stop(failover bool) (st Status, err error) {
 	if sdriver.driver != nil {
 		var failoverInt C.int = 0
 		if failover {
 			failoverInt = 1
 		}
 
-		C.scheduler_stop(C.SchedulerDriverPtr(sdriver.driver), failoverInt)
+		st = Status(C.scheduler_stop(C.SchedulerDriverPtr(sdriver.driver), failoverInt))
 	} else {
-		return errors.New("Stop() failed: scheduler driver not initialized")
+		err = ErrSchedulerNotInitialized
 	}
-	return nil
+	return
 }
 
-func (sdriver *MesosSchedulerDriver) Abort() error {
+func (sdriver *MesosSchedulerDriver) Abort() (st Status, err error) {
 	if sdriver.driver != nil {
-		C.scheduler_abort(C.SchedulerDriverPtr(sdriver.driver))
+		st = Status(C.scheduler_abort(C.SchedulerDriverPtr(sdriver.driver)))
 	} else {
-		return errors.New("Abort() failed: scheduler driver not initialized")
+		err = ErrSchedulerNotInitialized
 	}
-	return nil
+	return
 }
 
-func (sdriver *MesosSchedulerDriver) Join() error {
+func (sdriver *MesosSchedulerDriver) Join() (st Status, err error) {
 	if sdriver.driver != nil {
-		C.scheduler_join(C.SchedulerDriverPtr(sdriver.driver))
+		st = Status(C.scheduler_join(C.SchedulerDriverPtr(sdriver.driver)))
 	} else {
-		return errors.New("Join() failed: scheduler driver not initialized")
+		err = ErrSchedulerNotInitialized
 	}
-	return nil
+	return
 }
 
-func (sdriver *MesosSchedulerDriver) Run() error {
+func (sdriver *MesosSchedulerDriver) Run() (st Status, err error) {
 	if sdriver.driver != nil {
-		C.scheduler_run(C.SchedulerDriverPtr(sdriver.driver))
+		st = Status(C.scheduler_run(C.SchedulerDriverPtr(sdriver.driver)))
 	} else {
-		return errors.New("Run() failed: scheduler driver not initialized")
+		err = ErrSchedulerNotInitialized
 	}
-	return nil
+	return
 }
 
 func (sdriver *MesosSchedulerDriver) RequestResources(requests []*Request) error {
@@ -235,8 +248,7 @@ func (sdriver *MesosSchedulerDriver) RequestResources(requests []*Request) error
 			C.SchedulerDriverPtr(sdriver.driver),
 			&requestsObj)
 	} else {
-		return errors.New(
-			"RequestResources() failed: scheduler driver not initialized")
+		return ErrSchedulerNotInitialized
 	}
 
 	return nil
@@ -283,7 +295,7 @@ func (sdriver *MesosSchedulerDriver) LaunchTasks(
 			&tasksObj,
 			filters_)
 	} else {
-		return errors.New("LaunchTasks() failed: scheduler driver not initialized")
+		return ErrSchedulerNotInitialized
 	}
 
 	return nil
@@ -298,7 +310,7 @@ func (sdriver *MesosSchedulerDriver) KillTask(taskId *TaskID) error {
 
 		C.scheduler_killTask(C.SchedulerDriverPtr(sdriver.driver), &message)
 	} else {
-		return errors.New("KillTask() failed: scheduler driver not initialized")
+		return ErrSchedulerNotInitialized
 	}
 
 	return nil
@@ -328,7 +340,7 @@ func (sdriver *MesosSchedulerDriver) DeclineOffer(
 			&message,
 			filters_)
 	} else {
-		return errors.New("Start() failed: scheduler driver not initialized")
+		return ErrSchedulerNotInitialized
 	}
 	return nil
 }
@@ -337,7 +349,7 @@ func (sdriver *MesosSchedulerDriver) ReviveOffers() error {
 	if sdriver.driver != nil {
 		C.scheduler_reviveOffers(C.SchedulerDriverPtr(sdriver.driver))
 	} else {
-		return errors.New("ReviveOffers() failed: scheduler driver not initialized")
+		return ErrSchedulerNotInitialized
 	}
 	return nil
 }
@@ -365,8 +377,7 @@ func (sdriver *MesosSchedulerDriver) SendFrameworkMessage(
 			&slaveMessage,
 			cdata)
 	} else {
-		return errors.New(
-			"SendFrameworkMessage() failed: scheduler driver not initialized")
+		return ErrSchedulerNotInitialized
 	}
 
 	return nil
@@ -376,11 +387,9 @@ func (sdriver *MesosSchedulerDriver) Destroy() {
 	C.scheduler_destroy(sdriver.driver, sdriver.scheduler)
 }
 
+// Deprecated: this func adds little value to the binding API
 func (sdriver *MesosSchedulerDriver) Wait() {
-	for {
-		// For now, wait for juicy details.
-		runtime.Gosched()
-	}
+	select {}
 }
 
 ///////////////

--- a/mesos/scheduler_driver.cpp
+++ b/mesos/scheduler_driver.cpp
@@ -64,7 +64,8 @@ SchedulerPtrPair scheduler_init(
     SchedulerCallbacks* callbacks,
     void* payload,
     ProtobufObj* framework,
-    const char* master)
+    const char* master,
+    ProtobufObj* credobj)
 {
   TRACE("scheduler_init()\n");
   assert(master != NULL);
@@ -81,10 +82,21 @@ SchedulerPtrPair scheduler_init(
     return pair;
   }
 
-  MesosSchedulerDriver* driver = new MesosSchedulerDriver(
-     scheduler,
-     scheduler->info,
-     std::string(master));
+  Credential cred;
+  if(credobj && !utils::deserialize<Credential>(cred, credobj)) {
+    return pair;
+  }
+
+  MesosSchedulerDriver* driver = credobj ? 
+     new MesosSchedulerDriver(
+       scheduler,
+       scheduler->info,
+       std::string(master),
+       cred) : 
+     new MesosSchedulerDriver(
+       scheduler,
+       scheduler->info,
+       std::string(master));
 
   if (callbacks != NULL) {
     scheduler->callbacks = *callbacks;


### PR DESCRIPTION
These patches are currently incorporated into the kubernetes-mesos:framework_auth branch. Would be nice to get them into the upstream and rebase k8s-mesos on the updated native branch.
