### PR TITLE
restore the mesos package so that godep can fetch the native bindings

### DIFF
--- a/mesos/doc.go
+++ b/mesos/doc.go
@@ -1,0 +1,3 @@
+// This package was previously the home of the native bindings. Please use the
+// native branch if you need to build against the native bindings.
+package mesos


### PR DESCRIPTION
`godep restore` is broken for kubernetes-mesos because the `mesos` package was deleted with the move to pure language bindings. The Godep tool performs a `go get` before switching to the commit referenced in the Godeps.json file: this fails because go-get works from the master branch, and the `mesos` package no longer resides there. This PR re-adds that package as an empty, doc-only package that points users to the native bindings branch. This should resolve the Godep/go-get problem I'm facing in building the k8s-mesos master branch.
