### PR TITLE
Migrated completely to github.com/gogo/protobuf

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/mesos/mesos-go",
-	"GoVersion": "go1.3",
+	"GoVersion": "go1.4",
 	"Packages": [
 		"./..."
 	],
@@ -11,8 +11,8 @@
 			"Rev": "7dda39b2e7d5e265014674c5af696ba4186679e9"
 		},
 		{
-			"ImportPath": "code.google.com/p/gogoprotobuf/proto",
-			"Rev": "d228c1a206c3a756d7ec6cc3579d92d00c35a161"
+			"ImportPath": "github.com/gogo/protobuf/proto",
+			"Rev": "ab6cea4a44ef42b748cd88d2d372047b75806e0c"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",

--- a/examples/test_framework.go
+++ b/examples/test_framework.go
@@ -21,8 +21,8 @@
 package main
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"flag"
+	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	util "github.com/mesos/mesos-go/mesosutil"

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -20,8 +20,8 @@ package executor
 
 import (
 	"code.google.com/p/go-uuid/uuid"
-	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	"github.com/mesos/mesos-go/mesosproto"
 	"github.com/mesos/mesos-go/mesosutil"

--- a/executor/executor_intgr_test.go
+++ b/executor/executor_intgr_test.go
@@ -20,7 +20,7 @@ package executor
 
 import (
 	"code.google.com/p/go-uuid/uuid"
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	util "github.com/mesos/mesos-go/mesosutil"

--- a/mesosproto/Makefile
+++ b/mesosproto/Makefile
@@ -1,2 +1,2 @@
 all: *.proto
-	protoc --proto_path=${GOPATH}/src:${GOPATH}/src/code.google.com/p/gogoprotobuf/protobuf:. --gogo_out=. *.proto
+	protoc --proto_path=${GOPATH}/src:${GOPATH}/src/github.com/gogo/protobuf/protobuf:. --gogo_out=. *.proto

--- a/mesosproto/log.pb.go
+++ b/mesosproto/log.pb.go
@@ -29,7 +29,7 @@ package mesosproto
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"

--- a/mesosproto/log.proto
+++ b/mesosproto/log.proto
@@ -18,7 +18,7 @@
 
 package mesosproto;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 option (gogoproto.gostring_all) = true;
 option (gogoproto.equal_all) = true;

--- a/mesosproto/mesos.pb.go
+++ b/mesosproto/mesos.pb.go
@@ -7,7 +7,7 @@ package mesosproto
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
 
 import io1 "io"
 import math1 "math"

--- a/mesosproto/mesos.proto
+++ b/mesosproto/mesos.proto
@@ -18,7 +18,7 @@
 
 package mesosproto;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 option (gogoproto.gostring_all) = true;
 option (gogoproto.equal_all) = true;

--- a/mesosproto/messages.pb.go
+++ b/mesosproto/messages.pb.go
@@ -7,7 +7,7 @@ package mesosproto
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/mesosproto/messages.proto
+++ b/mesosproto/messages.proto
@@ -19,7 +19,7 @@
 package mesosproto;
 
 import "mesos.proto";
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 
 // TODO(benh): Provide comments for each of these messages. Also,

--- a/mesosproto/state.pb.go
+++ b/mesosproto/state.pb.go
@@ -7,7 +7,7 @@ package mesosproto
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
 
 import io2 "io"
 import fmt8 "fmt"

--- a/mesosproto/state.proto
+++ b/mesosproto/state.proto
@@ -18,7 +18,7 @@
 
 package mesosproto;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 option (gogoproto.gostring_all) = true;
 option (gogoproto.equal_all) = true;

--- a/mesosutil/mesosprotoutil.go
+++ b/mesosutil/mesosprotoutil.go
@@ -19,7 +19,7 @@
 package mesosutil
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 )
 

--- a/mesosutil/mesosprotoutil_test.go
+++ b/mesosutil/mesosprotoutil_test.go
@@ -19,7 +19,7 @@
 package mesosutil
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/messenger/message.go
+++ b/messenger/message.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/mesos-go/upid"
 )
 

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -24,7 +24,7 @@ import (
 	"reflect"
 	"time"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/mesos/mesos-go/upid"

--- a/messenger/messenger_test.go
+++ b/messenger/messenger_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/mesos-go/messenger/testmessage"
 	"github.com/mesos/mesos-go/upid"
 	"github.com/stretchr/testify/assert"

--- a/messenger/mocked_messenger.go
+++ b/messenger/mocked_messenger.go
@@ -21,7 +21,7 @@ package messenger
 import (
 	"reflect"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/mesos-go/upid"
 	"github.com/stretchr/testify/mock"
 )

--- a/messenger/testmessage/Makefile
+++ b/messenger/testmessage/Makefile
@@ -1,2 +1,2 @@
 all: testmessage.proto
-	protoc --proto_path=${GOPATH}/src:${GOPATH}/src/code.google.com/p/gogoprotobuf/protobuf:. --gogo_out=. testmessage.proto
+	protoc --proto_path=${GOPATH}/src:${GOPATH}/src/github.com/gogo/protobuf/protobuf:. --gogo_out=. testmessage.proto

--- a/messenger/testmessage/testmessage.pb.go
+++ b/messenger/testmessage/testmessage.pb.go
@@ -19,7 +19,7 @@ package testmessage
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"

--- a/messenger/testmessage/testmessage.proto
+++ b/messenger/testmessage/testmessage.proto
@@ -1,6 +1,6 @@
 package testmessage;
 
-import "code.google.com/p/gogoprotobuf/gogoproto/gogo.proto";
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 option (gogoproto.gostring_all) = true;
 option (gogoproto.equal_all) = true;

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -20,8 +20,8 @@ package scheduler
 
 import (
 	"code.google.com/p/go-uuid/uuid"
-	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/mesos/mesos-go/messenger"

--- a/scheduler/scheduler_intgr_test.go
+++ b/scheduler/scheduler_intgr_test.go
@@ -19,7 +19,7 @@
 package scheduler
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	util "github.com/mesos/mesos-go/mesosutil"

--- a/scheduler/scheduler_unit_test.go
+++ b/scheduler/scheduler_unit_test.go
@@ -19,8 +19,8 @@
 package scheduler
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	util "github.com/mesos/mesos-go/mesosutil"
 	"github.com/mesos/mesos-go/messenger"

--- a/testutil/testingutil.go
+++ b/testutil/testingutil.go
@@ -21,8 +21,8 @@ package testutil
 
 import (
 	"bytes"
-	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
 	"github.com/mesos/mesos-go/upid"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
There were some references to code.google.com/p/gogoprotobuf, I have moved them to refer to https://github.com/gogo/protobuf as the project has moved to github and hence the package names have changed too.

Also regenerated the Godeps file to reflect this change.