### PR TITLE
use framework's hostname to initialize scheduler's UPID hostname

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -129,8 +129,10 @@ func NewMesosSchedulerDriver(
 		driver.MasterPid = m
 	}
 
+	schedulerPid := &upid.UPID{ID: "scheduler(1)", Host: *framework.Hostname}
+
 	//TODO keep scheduler counter to for proper PID.
-	driver.messenger = messenger.NewMesosMessenger(&upid.UPID{ID: "scheduler(1)"})
+	driver.messenger = messenger.NewMesosMessenger(schedulerPid)
 	if err := driver.init(); err != nil {
 		log.Errorf("Failed to initialize the scheduler driver: %v\n", err)
 		return nil, err


### PR DESCRIPTION
Frameworks do not quite expose themselves properly to the Mesos Master unless UPID.Host is set to match the listen address (conveniently FrameworkInfo.Hostname).