### PR TITLE
fix broken KillTask, include frameworkID

### DIFF
--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -234,7 +234,7 @@ func (m *MesosMessenger) reportError(err error) {
 	case <-ctx.Done():
 		<-c // wait for Route to return
 	case e := <-c:
-		log.Error("failed to report error %v due to: %v", err, e)
+		log.Errorf("failed to report error %v due to: %v", err, e)
 	}
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -662,7 +662,10 @@ func (driver *MesosSchedulerDriver) KillTask(taskId *mesos.TaskID) (mesos.Status
 		return driver.Status(), fmt.Errorf("Not connected to master")
 	}
 
-	message := &mesos.KillTaskMessage{TaskId: taskId}
+	message := &mesos.KillTaskMessage{
+		FrameworkId: driver.FrameworkInfo.Id,
+		TaskId:      taskId,
+	}
 
 	if err := driver.send(driver.MasterPid, message); err != nil {
 		log.Errorf("Failed to send KillTask message: %v\n", err)


### PR DESCRIPTION
found a bug while migrating to pure bindings
https://github.com/mesosphere/kubernetes-mesos/issues/141