### PR TITLE
Allowing executor to listen on any port and bind to all network interfaces

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -19,6 +19,7 @@
 package executor
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"sync"
@@ -59,6 +60,13 @@ type MesosExecutorDriver struct {
 	tasks           map[string]*mesosproto.TaskInfo     // Key is a UUID string. TODO(yifan): Not used yet.
 }
 
+var (
+	executorHost = flag.String("mesos_executor_host", "0.0.0.0",
+		fmt.Sprintf("TCP4 address for the executor to bind"))
+	executorPort = flag.String("mesos_executor_port", "0",
+		fmt.Sprintf("TCP4 port for the executor to bind"))
+)
+
 // NewMesosExecutorDriver creates a new mesos executor driver.
 func NewMesosExecutorDriver(exec Executor) (*MesosExecutorDriver, error) {
 	if exec == nil {
@@ -78,7 +86,11 @@ func NewMesosExecutorDriver(exec Executor) (*MesosExecutorDriver, error) {
 		workDir:   ".",
 	}
 	// TODO(yifan): Set executor cnt.
-	driver.messenger = messenger.NewHttp(&upid.UPID{ID: "executor(1)"})
+	driver.messenger = messenger.NewHttp(&upid.UPID{
+		ID:   "executor(1)",
+		Host: *executorHost,
+		Port: *executorPort,
+	})
 	if err := driver.init(); err != nil {
 		log.Errorf("Failed to initialize the driver: %v\n", err)
 		return nil, err

--- a/messenger/http_transporter.go
+++ b/messenger/http_transporter.go
@@ -182,13 +182,6 @@ func (t *HTTPTransporter) Listen() error {
 	host := t.upid.Host
 	port := t.upid.Port
 
-	if host == "" {
-		host = "0.0.0.0"
-	}
-
-	if port == "" {
-		port = "0"
-	}
 	// NOTE: Explicitly specifies IPv4 because Libprocess
 	// only supports IPv4 for now.
 	ln, err := net.Listen("tcp4", net.JoinHostPort(host, port))

--- a/messenger/http_transporter.go
+++ b/messenger/http_transporter.go
@@ -181,6 +181,14 @@ func (t *HTTPTransporter) Install(msgName string) {
 func (t *HTTPTransporter) Listen() error {
 	host := t.upid.Host
 	port := t.upid.Port
+
+	if host == "" {
+		host = "0.0.0.0"
+	}
+
+	if port == "" {
+		port = "0"
+	}
 	// NOTE: Explicitly specifies IPv4 because Libprocess
 	// only supports IPv4 for now.
 	ln, err := net.Listen("tcp4", net.JoinHostPort(host, port))


### PR DESCRIPTION
This fixes #72 

@vladimirvivien @nqn This will allow the executor to listen on all interfaces and on any ports. I am not aware of any way it's possible to make an executor listen on a particular port and ip and have the slave communicate with it. At least, for Java based executors setting ip and port for executor isn't required.

Please let me know if there is any work around or merge this as soon as possible since this is kind of a blocker.