### PR TITLE
only care about znodes that start with 'info_'

### DIFF
--- a/detector/zoo/detect.go
+++ b/detector/zoo/detect.go
@@ -181,6 +181,9 @@ func selectTopNode(list []string) (node string) {
 	var leaderSeq uint64 = math.MaxUint64
 
 	for _, v := range list {
+		if !strings.HasPrefix(v, nodePrefix) {
+			continue // only care about participants
+		}
 		seqStr := strings.TrimPrefix(v, nodePrefix)
 		seq, err := strconv.ParseUint(seqStr, 10, 64)
 		if err != nil {


### PR DESCRIPTION
More data than just active electorate members show up under the /mesos znode.  The  participants all start with "info_" but there are other fields such as "log_replicas".

Only consider znodes with an "info_" prefix for consideration.  Without this patch there's this glogspam:

```
I0218 23:18:51.348273   28049 client.go:224] connecting to zookeeper..
I0218 23:18:51.349798   28049 client.go:176] zookeeper client connected
W0218 23:18:52.354450   28049 detect.go:187] unexpected zk node format 'log_replicas': strconv.ParseUint: parsing "log_replicas": invalid syntax
I0218 23:18:52.357060   28049 scheduler.go:251] New master master@10.141.141.10:5050 detected
```

Technically everything works, but there's no point to warn if you don't have to.
