### PR TITLE
Use examples build target when invoking the all target as it calls both test-framework and test-executor already

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LIBS :=	\
 
 .PHONY: format all go-clean pkg-build-install test-framework test-executor test test.v
 
-all: go-clean pkg-build-install test-framework test-executor
+all: go-clean pkg-build-install examples
 
 go-clean:
 	go clean


### PR DESCRIPTION
trivial; should have been done in prior PR but just noticed it..