### PR TITLE
Rename test-executor and test-framework references to example-executor and example-scheduler to be more consistent with example naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,8 +91,8 @@ _testmain.go
 junit_*
 
 # mesos-go specific
-examples/test-framework
-examples/test-executor
+examples/example-scheduler
+examples/example-executor
 
 #webide
 .c9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 From busybox:ubuntu-14.04 
-ADD ./example_executor/example_executor /bin/test-executor
+ADD ./example_executor/example_executor /bin/example-executor

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LIBS :=	\
 	scheduler \
 	upid
 
-.PHONY: format all go-clean pkg-build-install test-framework test-executor test test.v
+.PHONY: format all go-clean pkg-build-install example-scheduler example-executor test test.v
 
 all: go-clean pkg-build-install examples
 
@@ -28,15 +28,15 @@ go-clean:
 pkg-build-install:
 	go install -v ${LIBS:%=./%}
 
-examples: test-framework test-executor
+examples: example-scheduler example-executor
 
-test-framework:
+example-scheduler:
 	rm -rf ${EXAMPLES}/$@
-	go build -o ${EXAMPLES}/$@ ${EXAMPLES}/test_framework.go 
+	go build -o ${EXAMPLES}/$@ ${EXAMPLES}/example_scheduler.go
 
-test-executor:
+example-executor:
 	rm -rf ${EXAMPLES}/$@
-	go build -o ${EXAMPLES}/$@ ${EXAMPLES}/test_executor.go 
+	go build -o ${EXAMPLES}/$@ ${EXAMPLES}/example_executor.go
 
 format:
 	go fmt ${LIBS:%=$(PKG_PREFIX)/%}

--- a/README.md
+++ b/README.md
@@ -46,24 +46,24 @@ Use the following steps to build the example scheduler and executor:
 ```
 $ cd <go-workspace>/src/github.com/mesos/mesos-go/examples
 
-# build test-framework
-$ go build -tags=test-sched -o test-framework test_framework.go
+# build example-scheduler
+$ go build -tags=example-sched -o example-scheduler example_scheduler.go
 
-# build test-executor
-$ go build -tags=test-exec -o test-executor test_executor.go
+# build example-executor
+$ go build -tags=example-exec -o example-executor example_executor.go
 ```
 
 Or by using the top level Makefile:
 ```
 $ cd <go-workspace>/src/github.com/mesos/mesos-go
 
-# build test-framework
-$ make test-framework
+# build example-scheduler
+$ make example-scheduler
 
-# build test-executor
-$ make test-executor
+# build example-executor
+$ make example-executor
 
-# build test-framework and test-executor at the same time
+# build example-scheduler and example-executor at the same time
 $ make examples
 ```
 
@@ -79,16 +79,16 @@ See http://mesos.apache.org/gettingstarted/ for getting started with Apache Meso
 ```
 $ cd <go-workspace>/src/github.com/mesos/mesos-go
 $ cd examples
-$ ./test-framework --master=127.0.0.1:5050 --executor="<go-workspace>/src/github.com/mesos/mesos-go/examples/test-executor" --logtostderr=true
+$ ./example-scheduler --master=127.0.0.1:5050 --executor="<go-workspace>/src/github.com/mesos/mesos-go/examples/example-executor" --logtostderr=true
 ```
-Note: you must provide the fully-qualified path to the `test-executor` binary.  If all goes well, you should see output about task completion.  You can also point your browser to the Mesos GUI http://127.0.0.1:5050/ to validate the framework activities.
+Note: you must provide the fully-qualified path to the `example-executor` binary.  If all goes well, you should see output about task completion.  You can also point your browser to the Mesos GUI http://127.0.0.1:5050/ to validate the framework activities.
 
 ### Running the Go Scheduler with Other Executors
-You can also use the Go `test-framework` with executors written in other languages such as  `Python` or `Java`  for further validation (note: to use these executors requires a build of the mesos source code with `make check`):
+You can also use the Go `example-scheduler` with executors written in other languages such as  `Python` or `Java`  for further validation (note: to use these executors requires a build of the mesos source code with `make check`):
 ```
-$ ./test-framework --master=127.0.0.1:5050 --executor="<mesos-build>/src/examples/python/test-executor" --logtostderr=true
+$ ./example-scheduler --master=127.0.0.1:5050 --executor="<mesos-build>/src/examples/python/test-executor" --logtostderr=true
 ```
 Similarly for the Java version:
 ```
-$ ./test-framework --master=127.0.0.1:5050 --executor="<mesos-build>/src/examples/java/test-executor" --logtostderr=true
+$ ./example-scheduler --master=127.0.0.1:5050 --executor="<mesos-build>/src/examples/java/test-executor" --logtostderr=true
 ```

--- a/examples/example_executor.go
+++ b/examples/example_executor.go
@@ -1,4 +1,4 @@
-// +build test-exec
+// +build example-exec
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/examples/example_scheduler.go
+++ b/examples/example_scheduler.go
@@ -1,4 +1,4 @@
-// +build test-sched
+// +build example-sched
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -52,7 +52,7 @@ var (
 	authProvider = flag.String("mesos_authentication_provider", sasl.ProviderName,
 		fmt.Sprintf("Authentication provider to use, default is SASL that supports mechanisms: %+v", mech.ListSupported()))
 	master              = flag.String("master", "127.0.0.1:5050", "Master address <ip:port>")
-	executorPath        = flag.String("executor", "./test_executor", "Path to test executor")
+	executorPath        = flag.String("executor", "./example_executor", "Path to test executor")
 	taskCount           = flag.String("task-count", "5", "Total task count to run.")
 	mesosAuthPrincipal  = flag.String("mesos_authentication_principal", "", "Mesos authentication principal.")
 	mesosAuthSecretFile = flag.String("mesos_authentication_secret_file", "", "Mesos authentication secret file.")


### PR DESCRIPTION
nit-picky but having the "test" prefix for examples always seemed a little inconsistent to me