### PR TITLE
tests: Fail fast on drivers' construction errors

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -59,11 +59,15 @@ func clearEnvironments(t *testing.T) {
 	assert.NoError(t, os.Setenv("MESOS_EXECUTOR_ID", ""))
 }
 
-func newTestExecutorDriver(exec Executor) (*MesosExecutorDriver, error) {
+func newTestExecutorDriver(t *testing.T, exec Executor) *MesosExecutorDriver {
 	dconfig := DriverConfig{
 		Executor: exec,
 	}
-	return NewMesosExecutorDriver(dconfig)
+	driver, err := NewMesosExecutorDriver(dconfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return driver
 }
 
 func createTestExecutorDriver(t *testing.T) (
@@ -74,9 +78,7 @@ func createTestExecutorDriver(t *testing.T) (
 	exec := NewMockedExecutor()
 
 	setEnvironments(t, "", false)
-	driver, err := newTestExecutorDriver(exec)
-	assert.NoError(t, err)
-	assert.NotNil(t, driver)
+	driver := newTestExecutorDriver(t, exec)
 
 	messenger := messenger.NewMockedMessenger()
 	messenger.On("Start").Return(nil)
@@ -96,8 +98,7 @@ func TestExecutorDriverStartFailedToParseEnvironment(t *testing.T) {
 	clearEnvironments(t)
 	exec := NewMockedExecutor()
 	exec.On("Error").Return(nil)
-	driver, err := newTestExecutorDriver(exec)
-	assert.Error(t, err)
+	driver := newTestExecutorDriver(t, exec)
 	assert.Nil(t, driver)
 }
 
@@ -105,8 +106,7 @@ func TestExecutorDriverStartFailedToStartMessenger(t *testing.T) {
 	exec := NewMockedExecutor()
 
 	setEnvironments(t, "", false)
-	driver, err := newTestExecutorDriver(exec)
-	assert.NoError(t, err)
+	driver := newTestExecutorDriver(t, exec)
 	assert.NotNil(t, driver)
 	messenger := messenger.NewMockedMessenger()
 	driver.messenger = messenger
@@ -129,9 +129,7 @@ func TestExecutorDriverStartFailedToSendRegisterMessage(t *testing.T) {
 	exec := NewMockedExecutor()
 
 	setEnvironments(t, "", false)
-	driver, err := newTestExecutorDriver(exec)
-	assert.NoError(t, err)
-	assert.NotNil(t, driver)
+	driver := newTestExecutorDriver(t, exec)
 	messenger := messenger.NewMockedMessenger()
 	driver.messenger = messenger
 
@@ -157,9 +155,7 @@ func TestExecutorDriverStartSucceed(t *testing.T) {
 	exec := NewMockedExecutor()
 	exec.On("Error").Return(nil)
 
-	driver, err := newTestExecutorDriver(exec)
-	assert.NoError(t, err)
-	assert.NotNil(t, driver)
+	driver := newTestExecutorDriver(t, exec)
 
 	messenger := messenger.NewMockedMessenger()
 	driver.messenger = messenger
@@ -196,9 +192,8 @@ func TestExecutorDriverRun(t *testing.T) {
 	exec := NewMockedExecutor()
 	exec.On("Error").Return(nil)
 
-	driver, err := newTestExecutorDriver(exec)
+	driver := newTestExecutorDriver(t, exec)
 	driver.messenger = messenger
-	assert.NoError(t, err)
 	assert.True(t, driver.stopped)
 
 	checker := healthchecker.NewMockedHealthChecker()
@@ -233,9 +228,8 @@ func TestExecutorDriverJoin(t *testing.T) {
 	exec := NewMockedExecutor()
 	exec.On("Error").Return(nil)
 
-	driver, err := newTestExecutorDriver(exec)
+	driver := newTestExecutorDriver(t, exec)
 	driver.messenger = messenger
-	assert.NoError(t, err)
 	assert.True(t, driver.stopped)
 
 	checker := healthchecker.NewMockedHealthChecker()

--- a/scheduler/scheduler_intgr_test.go
+++ b/scheduler/scheduler_intgr_test.go
@@ -168,9 +168,7 @@ func (suite *SchedulerIntegrationTestSuite) configure(frameworkId *mesos.Framewo
 	suite.sched = newTestScheduler(suite)
 	suite.sched.ch = make(chan bool, 10) // big enough that it doesn't block callback processing
 
-	var err error
-	suite.driver, err = newTestSchedulerDriver(suite.sched, suite.framework, suite.server.Addr, nil)
-	suite.NoError(err)
+	suite.driver = newTestSchedulerDriver(suite.T(), suite.sched, suite.framework, suite.server.Addr, nil)
 
 	suite.config(frameworkId, suite)
 


### PR DESCRIPTION
Running tests locally with go test ./... was causing several panics due
to failing DNS queries for the locally set hostname ("lookup senart: no such host")

The assertion library being used wasn't failing fast in presence of such errors
being returned by driver constructors. This resulted in nil drivers
being accessed and hence causing panics.

This change set makes these constructors abort the tests immediately instead of
delaying the error reporting.