### PR TITLE
Log warning if no username can be obtained (and none is given).

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -161,7 +161,7 @@ func NewMesosSchedulerDriver(config DriverConfig) (initializedDriver *MesosSched
 			if err != nil {
 				log.Warningln("Failed to obtain username: %v", err)
 			} else {
-				log.Warningln("Failed to obtain username.")
+				log.Warningf("Failed to obtain username.")
 			}
 			framework.User = proto.String("")
 		} else {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -158,6 +158,11 @@ func NewMesosSchedulerDriver(config DriverConfig) (initializedDriver *MesosSched
 	if framework.GetUser() == "" {
 		user, err := user.Current()
 		if err != nil || user == nil {
+			if err != nil {
+				log.Warningln("Failed to obtain username: %v", err)
+			} else {
+				log.Warningln("Failed to obtain username.")
+			}
 			framework.User = proto.String("")
 		} else {
 			framework.User = proto.String(user.Username)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -159,9 +159,9 @@ func NewMesosSchedulerDriver(config DriverConfig) (initializedDriver *MesosSched
 		user, err := user.Current()
 		if err != nil || user == nil {
 			if err != nil {
-				log.Warningln("Failed to obtain username: %v", err)
+				log.Warningf("Failed to obtain username: %v\n", err)
 			} else {
-				log.Warningf("Failed to obtain username.")
+				log.Warningln("Failed to obtain username.")
 			}
 			framework.User = proto.String("")
 		} else {


### PR DESCRIPTION
I crosscompiled the example_scheduler on my macbook and copied it over to the playa-vm. Here the `user.Current()` call failed (because its not support in cross-compiled binaries in go) __silently__.

This PR logs a warning if no username is given in the `DriverConfig` and is failed to be obtained by `user.Current()`.