### PR TITLE
Support PID hosts with IPs

### DIFF
--- a/detector/factory.go
+++ b/detector/factory.go
@@ -126,7 +126,9 @@ func CreateMasterInfo(pid *upid.UPID) *mesos.MasterInfo {
 	}
 	//TODO(jdef) what about (future) ipv6 support?
 	var ipv4 net.IP
-	if addrs, err := net.LookupIP(pid.Host); err == nil {
+	if ipv4 = net.ParseIP(pid.Host); ipv4 != nil {
+		// Intentionally left empty. ipv4 is successfully parsed, so we can skip the other versions
+        } else if addrs, err := net.LookupIP(pid.Host); err == nil {
 		for _, ip := range addrs {
 			if ip = ip.To4(); ip != nil {
 				ipv4 = ip

--- a/detector/factory.go
+++ b/detector/factory.go
@@ -127,7 +127,9 @@ func CreateMasterInfo(pid *upid.UPID) *mesos.MasterInfo {
 	//TODO(jdef) what about (future) ipv6 support?
 	var ipv4 net.IP
 	if ipv4 = net.ParseIP(pid.Host); ipv4 != nil {
-		// Intentionally left empty. ipv4 is successfully parsed, so we can skip the other versions
+		// This is needed for the people cross-compiling from macos to linux.
+		// The cross-compiled version of net.LookupIP() fails to handle plain IPs.
+		// See https://github.com/mesos/mesos-go/pull/117
         } else if addrs, err := net.LookupIP(pid.Host); err == nil {
 		for _, ip := range addrs {
 			if ip = ip.To4(); ip != nil {


### PR DESCRIPTION
While playing around with https://github.com/mesosphere/playa-mesos and mesos-go I failed to connect the example framework to the master. The master identified itself as `master@127.0.1.1:5050` which failed the parsing logic in `detector/factory.go`.

This PR fixes `CreateMasterInfo()` to support PIDs with IPs as the hostname.