### PR TITLE
only set upid.Host and upid.Port if Host is unset

### DIFF
--- a/messenger/http_transporter.go
+++ b/messenger/http_transporter.go
@@ -245,7 +245,15 @@ func (t *HTTPTransporter) listen() error {
 	}
 	// Save the host:port in case they are not specified in upid.
 	host, port, _ = net.SplitHostPort(ln.Addr().String())
-	t.upid.Host, t.upid.Port = host, port
+
+	if len(t.upid.Host) == 0 {
+		t.upid.Host = host
+	}
+
+	if len(t.upid.Port) == 0 || t.upid.Port == "0" {
+		t.upid.Port = port
+	}
+
 	t.listener = ln
 	return nil
 }

--- a/messenger/http_transporter_test.go
+++ b/messenger/http_transporter_test.go
@@ -2,6 +2,7 @@ package messenger
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -263,6 +264,66 @@ func TestTransporterStartAndStop(t *testing.T) {
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
+	}
+}
+
+func TestMutatedHostUPid(t *testing.T) {
+	serverId := "testserver"
+	serverPort := getNewPort()
+	serverHost := "127.0.0.1"
+	serverAddr := serverHost + ":" + strconv.Itoa(serverPort)
+
+	// override the upid.Host with this listener IP
+	addr := net.ParseIP("127.0.1.1")
+
+	// setup receiver (server) process
+	uPid, err := upid.Parse(fmt.Sprintf("%s@%s", serverId, serverAddr))
+	assert.NoError(t, err)
+	receiver := NewHTTPTransporter(uPid, addr)
+
+	err = receiver.listen()
+	assert.NoError(t, err)
+
+	if receiver.upid.Host != "127.0.0.1" {
+		t.Fatalf("reciever.upid.Host was expected to return %s, got %s\n", serverHost, receiver.upid.Host)
+	}
+
+	if receiver.upid.Port != strconv.Itoa(serverPort) {
+		t.Fatalf("receiver.upid.Port was expected to return %d, got %s\n", serverPort, receiver.upid.Port)
+	}
+}
+
+func TestEmptyHostPortUPid(t *testing.T) {
+	serverId := "testserver"
+	serverPort := getNewPort()
+	serverHost := "127.0.0.1"
+	serverAddr := serverHost + ":" + strconv.Itoa(serverPort)
+
+	// setup receiver (server) process
+	uPid, err := upid.Parse(fmt.Sprintf("%s@%s", serverId, serverAddr))
+	assert.NoError(t, err)
+
+	// Unset upid host and port
+	uPid.Host = ""
+	uPid.Port = ""
+
+	// override the upid.Host with this listener IP
+	addr := net.ParseIP("127.0.1.1")
+
+	receiver := NewHTTPTransporter(uPid, addr)
+
+	err = receiver.listen()
+	assert.NoError(t, err)
+
+	// This should be the host that overrides as uPid.Host is empty
+	if receiver.upid.Host != "127.0.1.1" {
+		t.Fatalf("reciever.upid.Host was expected to return %s, got %s\n", serverHost, receiver.upid.Host)
+	}
+
+	// This should end up being a random port, not the server port as uPid
+	// port is empty
+	if receiver.upid.Port == strconv.Itoa(serverPort) {
+		t.Fatalf("receiver.upid.Port was not expected to return %d, got %s\n", serverPort, receiver.upid.Port)
 	}
 }
 


### PR DESCRIPTION
This commit checks if `upid.Host` is set in the http_transporter and sets it
to the value that it determines if unset.

The original problem was that I was trying to run a scheduler on 0.0.0.0 as
listening host and have OverrideHostname set, this should have led to the
master thinking that I was sending messages from HostnameOverride, instead the
http_transporter function listen(), mutated the upid.Host and the master would
always look up 0.0.0.0.

The patch has been tested by running a scheduler against a Mesos cluster with
the scheduler bound to 0.0.0.0 and HostnameOverride in DriverConfig to an
external IP.

Thanks!