### PR TITLE
Fix TestExecutorDriverStartFailedToParseEnvironment

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -98,8 +98,10 @@ func TestExecutorDriverStartFailedToParseEnvironment(t *testing.T) {
 	clearEnvironments(t)
 	exec := NewMockedExecutor()
 	exec.On("Error").Return(nil)
-	driver := newTestExecutorDriver(t, exec)
+	dconfig := DriverConfig{Executor: exec}
+	driver, err := NewMesosExecutorDriver(dconfig)
 	assert.Nil(t, driver)
+	assert.Error(t, err)
 }
 
 func TestExecutorDriverStartFailedToStartMessenger(t *testing.T) {


### PR DESCRIPTION
```
=== RUN TestExecutorDriverStartFailedToParseEnvironment
E0605 12:29:40.985421 40983 executor.go:117] Failed to parse environments: Cannot find MESOS_SLAVE_PID in the environment
E0605 12:29:40.986176 40983 executor.go:104] failed to initialize the driver: Cannot find MESOS_SLAVE_PID in the environment
--- FAIL: TestExecutorDriverStartFailedToParseEnvironment (0.00s)
	executor_test.go:68: Cannot find MESOS_SLAVE_PID in the environment
FAIL
exit status 1
FAIL	github.com/mesos/mesos-go/executor	0.011s
```