### PR TITLE
messenger: Make tests pass on Mac OSX

### DIFF
--- a/messenger/http_transporter.go
+++ b/messenger/http_transporter.go
@@ -21,7 +21,6 @@ package messenger
 import (
 	"bytes"
 	"fmt"
-	"github.com/mesos/mesos-go/upid"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -33,6 +32,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/mesos/mesos-go/upid"
 	"golang.org/x/net/context"
 )
 
@@ -235,7 +235,14 @@ func (t *HTTPTransporter) listen() error {
 	} else {
 		host = t.upid.Host
 	}
-	port := t.upid.Port
+
+	var port string
+	if t.upid.Port != "" {
+		port = t.upid.Port
+	} else {
+		port = "0"
+	}
+
 	// NOTE: Explicitly specifies IPv4 because Libprocess
 	// only supports IPv4 for now.
 	ln, err := net.Listen("tcp4", net.JoinHostPort(host, port))

--- a/messenger/http_transporter_test.go
+++ b/messenger/http_transporter_test.go
@@ -274,7 +274,7 @@ func TestMutatedHostUPid(t *testing.T) {
 	serverAddr := serverHost + ":" + strconv.Itoa(serverPort)
 
 	// override the upid.Host with this listener IP
-	addr := net.ParseIP("127.0.1.1")
+	addr := net.ParseIP("127.0.0.2")
 
 	// setup receiver (server) process
 	uPid, err := upid.Parse(fmt.Sprintf("%s@%s", serverId, serverAddr))
@@ -308,7 +308,7 @@ func TestEmptyHostPortUPid(t *testing.T) {
 	uPid.Port = ""
 
 	// override the upid.Host with this listener IP
-	addr := net.ParseIP("127.0.1.1")
+	addr := net.ParseIP("127.0.0.2")
 
 	receiver := NewHTTPTransporter(uPid, addr)
 
@@ -316,7 +316,7 @@ func TestEmptyHostPortUPid(t *testing.T) {
 	assert.NoError(t, err)
 
 	// This should be the host that overrides as uPid.Host is empty
-	if receiver.upid.Host != "127.0.1.1" {
+	if receiver.upid.Host != "127.0.0.2" {
 		t.Fatalf("reciever.upid.Host was expected to return %s, got %s\n", serverHost, receiver.upid.Host)
 	}
 


### PR DESCRIPTION
This commit makes tests pass by using more commonly available loopback
addresses and explicitly requesting random port assigment with port 0.