### PR TITLE
Read gofmt diff to dummy variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format:
 	gofmt -s -w .
 
 formatted:
-	! gofmt -s -d . 2>&1 | read
+	! gofmt -s -d . 2>&1 | read diff
 
 vet:
 	go vet ./...


### PR DESCRIPTION
This commit fixes a Travis CI issue where their sandbox shell complains
if `read` doesn't receive any arguments.