### PR TITLE
Build instructions now use GOPATH and build godep

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -40,6 +40,10 @@
 			"ImportPath": "golang.org/x/net/context",
 			"Comment": "null-214",
 			"Rev": "cbcac7bb8415db9b6cb4d1ebab1dc9afbd688b97"
+		},
+		{
+			"ImportPath": "golang.org/x/text",
+			"Rev": "3eb7007b740b66a77f3c85f2660a0240b284115a"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ This is a very early version of the project.  Howerver, here is a list of things
 ## Build Instructions
 The following instructions is to build the code from `github`.The project uses the `GoDep` for dependency management.
 ```
-$ cd <go-workspace>/src/
-$ mkdir -p github.com/mesos
-$ cd github.com/mesos
+$ export GOPATH=<go-workspace>
+$ mkdir -p ${GOPATH}/src/github.com/mesos
+$ cd ${GOPATH}/src/github.com/mesos
 $ git clone https://github.com/mesos/mesos-go.git
 $ cd mesos-go
 $ go get github.com/tools/godep
-$ godep restore
+$ go build github.com/tools/godep
+$ ./godep restore
+$ cd ../../../
 $ go build ./...
 ```
 The previous will build the code base.  


### PR DESCRIPTION
Previously godep was fetched, but not built. Path to it was also not specified.

This also includes an added godep dependency on golang.org/x/text which was missing and breaking the build.