### PR TITLE
Port libprocess PID parser

### DIFF
--- a/upid/upid.go
+++ b/upid/upid.go
@@ -21,7 +21,12 @@ package upid
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
+)
+
+var (
+	validUpid = regexp.MustCompile(`[A-Za-z0-9_\-]+@[A-Za-z0-9_\-\.]+:[1-9][0-9]*`)
 )
 
 // UPID is a equivalent of the UPID in libprocess.
@@ -33,6 +38,10 @@ type UPID struct {
 
 // Parse parses the UPID from the input string.
 func Parse(input string) (*UPID, error) {
+	if !validUpid.MatchString(input) {
+		return nil, fmt.Errorf("Invalid UPID provided. Expected format <id>@<host>:<port>")
+	}
+
 	upid := new(UPID)
 
 	splits := strings.Split(input, "@")


### PR DESCRIPTION
More robust validation of uid string using Regexp

EDIT: Let's port libprocess parser instead: https://github.com/apache/mesos/blob/0.24.0/3rdparty/libprocess/src/pid.cpp#L84