### PR TITLE
Use container-based infra for travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: go
 go: 
 - 1.3


### PR DESCRIPTION
As per the migration guide http://docs.travis-ci.com/user/migrating-from-legacy/, we just need to add `sudo: false` to `.travis.yml` file.