### PR TITLE
Allow a different address published than binded.

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -41,6 +41,7 @@ type DriverConfig struct {
 	HostnameOverride string                              // optional
 	BindingAddress   net.IP                              // optional
 	BindingPort      uint16                              // optional
+	PublishedAddress net.IP                              // optional
 	NewMessenger     func() (messenger.Messenger, error) // optional
 }
 
@@ -82,7 +83,7 @@ func NewMesosExecutorDriver(config DriverConfig) (*MesosExecutorDriver, error) {
 	if newMessenger == nil {
 		newMessenger = func() (messenger.Messenger, error) {
 			process := process.New("executor")
-			return messenger.ForHostname(process, hostname, config.BindingAddress, config.BindingPort)
+			return messenger.ForHostname(process, hostname, config.BindingAddress, config.BindingPort, config.PublishedAddress)
 		}
 	}
 

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -78,7 +78,7 @@ type MesosMessenger struct {
 
 // ForHostname creates a new default messenger (HTTP), using UPIDBindingAddress to
 // determine the binding-address used for both the UPID.Host and Transport binding address.
-func ForHostname(proc *process.Process, hostname string, bindingAddress net.IP, port uint16) (Messenger, error) {
+func ForHostname(proc *process.Process, hostname string, bindingAddress net.IP, port uint16, publishedAddress net.IP) (Messenger, error) {
 	upid := &upid.UPID{
 		ID:   proc.Label(),
 		Port: strconv.Itoa(int(port)),
@@ -87,7 +87,21 @@ func ForHostname(proc *process.Process, hostname string, bindingAddress net.IP, 
 	if err != nil {
 		return nil, err
 	}
-	upid.Host = host
+
+	var publishedHost string
+	if publishedAddress != nil {
+		publishedHost, err = UPIDBindingAddress(hostname, publishedAddress)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if publishedHost != "" {
+		upid.Host = publishedHost
+	} else {
+		upid.Host = host
+	}
+
 	return NewHttpWithBindingAddress(upid, bindingAddress), nil
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -86,6 +86,7 @@ type DriverConfig struct {
 	HostnameOverride string                                // optional
 	BindingAddress   net.IP                                // optional
 	BindingPort      uint16                                // optional
+	PublishedAddress net.IP                                // optional
 	NewMessenger     func() (messenger.Messenger, error)   // optional
 }
 
@@ -196,7 +197,7 @@ func NewMesosSchedulerDriver(config DriverConfig) (initializedDriver *MesosSched
 	if newMessenger == nil {
 		newMessenger = func() (messenger.Messenger, error) {
 			process := process.New("scheduler")
-			return messenger.ForHostname(process, hostname, config.BindingAddress, config.BindingPort)
+			return messenger.ForHostname(process, hostname, config.BindingAddress, config.BindingPort, config.PublishedAddress)
 		}
 	}
 


### PR DESCRIPTION
Currently we only allow setting the binding address, which is what ip/port the messenger is going to bind to and be sending to the master as the UPID host.
However in some hosts the public ip differs than the private local ip that it can bind to, so allow publishing  a differnet ip can allow the master to connect back from a different public ip.