### PR TITLE
added role as a parameter to the Go example framework

### DIFF
--- a/examples/example_executor.go
+++ b/examples/example_executor.go
@@ -23,6 +23,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	exec "github.com/mesos/mesos-go/executor"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 )

--- a/examples/example_scheduler.go
+++ b/examples/example_scheduler.go
@@ -56,6 +56,7 @@ var (
 	taskCount           = flag.String("task-count", "5", "Total task count to run.")
 	mesosAuthPrincipal  = flag.String("mesos_authentication_principal", "", "Mesos authentication principal.")
 	mesosAuthSecretFile = flag.String("mesos_authentication_secret_file", "", "Mesos authentication secret file.")
+	role                = flag.String("role", "*", "Role to login framework with")
 )
 
 type ExampleScheduler struct {
@@ -129,8 +130,8 @@ func (sched *ExampleScheduler) ResourceOffers(driver sched.SchedulerDriver, offe
 				SlaveId:  offer.SlaveId,
 				Executor: sched.executor,
 				Resources: []*mesos.Resource{
-					util.NewScalarResource("cpus", CPUS_PER_TASK),
-					util.NewScalarResource("mem", MEM_PER_TASK),
+					util.NewScalarResource("cpus", CPUS_PER_TASK, util.Role(role)),
+					util.NewScalarResource("mem", MEM_PER_TASK, util.Role(role)),
 				},
 			}
 			log.Infof("Prepared task: %s with offer %s for launch\n", task.GetName(), offer.Id.GetValue())

--- a/mesosutil/mesosprotoutil.go
+++ b/mesosutil/mesosprotoutil.go
@@ -36,28 +36,49 @@ func FilterResources(resources []*mesos.Resource, filter func(*mesos.Resource) b
 	return result
 }
 
-func NewScalarResource(name string, val float64) *mesos.Resource {
-	return &mesos.Resource{
+// A ResourceOpt is a functional option type for mesos.Resources.
+type ResourceOpt func(*mesos.Resource)
+
+// Role returns a ResourceOpt that sets the Role of a
+// *mesos.Resource to the given value.
+func Role(s *string) ResourceOpt {
+	return func(r *mesos.Resource) { r.Role = s }
+}
+
+func NewScalarResource(name string, val float64, resOpt ...ResourceOpt) *mesos.Resource {
+	resource := &mesos.Resource{
 		Name:   proto.String(name),
 		Type:   mesos.Value_SCALAR.Enum(),
 		Scalar: &mesos.Value_Scalar{Value: proto.Float64(val)},
 	}
+	for _, opt := range resOpt {
+		opt(resource)
+	}
+	return resource
 }
 
-func NewRangesResource(name string, ranges []*mesos.Value_Range) *mesos.Resource {
-	return &mesos.Resource{
+func NewRangesResource(name string, ranges []*mesos.Value_Range, resOpt ...ResourceOpt) *mesos.Resource {
+	resource := &mesos.Resource{
 		Name:   proto.String(name),
 		Type:   mesos.Value_RANGES.Enum(),
 		Ranges: &mesos.Value_Ranges{Range: ranges},
 	}
+	for _, opt := range resOpt {
+		opt(resource)
+	}
+	return resource
 }
 
-func NewSetResource(name string, items []string) *mesos.Resource {
-	return &mesos.Resource{
+func NewSetResource(name string, items []string, resOpt ...ResourceOpt) *mesos.Resource {
+	resource := &mesos.Resource{
 		Name: proto.String(name),
 		Type: mesos.Value_SET.Enum(),
 		Set:  &mesos.Value_Set{Item: items},
 	}
+	for _, opt := range resOpt {
+		opt(resource)
+	}
+	return resource
 
 }
 


### PR DESCRIPTION
In order to take advantage of slaves offering specific resources for specific roles, the framework must be able to register as a certain role and submit jobs for resources with this role.  This PR adds the `--role` flag to the CLI.  All resources offered should match the `role` specified, and the tasks should be submitted with resources matching this `role`.