### PR TITLE
Release v0.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+2015-09-15: v0.0.1
+  First tagged release ever!
+  Mesos 0.24.0 and 0.23.0 compatibility.

--- a/mesosutil/constants.go
+++ b/mesosutil/constants.go
@@ -2,5 +2,5 @@ package mesosutil
 
 const (
 	// MesosVersion indicates the supported mesos version.
-	MesosVersion = "0.23.0"
+	MesosVersion = "0.24.0"
 )


### PR DESCRIPTION
This PR introduces tagged semantic versioned releases and a `CHANGELOG`. Once the PR is merged, I'll tag the commit with two tags:

1. **v0.0.1**: mesos-go semantic version
2. **mesos-0.24.0**: mesos version compatibility

Fixes #167