### PR TITLE
fix panic-inducing NPE in ZK child watcher

### DIFF
--- a/detector/zoo/client2.go
+++ b/detector/zoo/client2.go
@@ -79,7 +79,7 @@ func (c *client2) watchChildren(path string) (string, <-chan []string, <-chan er
 			}
 			e := <-ev // wait for the next watch-related event
 			if e.Err != nil {
-				errCh <- err
+				errCh <- e.Err
 				return
 			}
 		}


### PR DESCRIPTION
```
E0916 12:58:21.754043   13274 scheduler.go:202] Mesos master disconnected.
...
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x85d5d1]

goroutine 52 [running]:
github.com/mesos/mesos-go/detector/zoo.(*MasterDetector).detect(0xc820124a20, 0x7f2b73fc0ec8, 0xc820113b00)
        /home/tyler/src/go/src/github.com/mesosphere/etcd-mesos/Godeps/_workspace/src/github.com/mesos/mesos-go/detector/zoo/detect.go:294 +0xa91
created by github.com/mesos/mesos-go/detector/zoo.(*MasterDetector).Detect
        /home/tyler/src/go/src/github.com/mesosphere/etcd-mesos/Godeps/_workspace/src/github.com/mesos/mesos-go/detector/zoo/detect.go:263 +0x594
```