### PR TITLE
Removed pointer receiver from UPID.String() method

### DIFF
--- a/upid/upid.go
+++ b/upid/upid.go
@@ -49,10 +49,7 @@ func Parse(input string) (*UPID, error) {
 }
 
 // String returns the string representation.
-func (u *UPID) String() string {
-	if u == nil {
-		return ""
-	}
+func (u UPID) String() string {
 	return fmt.Sprintf("%s@%s:%s", u.ID, u.Host, u.Port)
 }
 


### PR DESCRIPTION
Removed pointer receiver from UPID.String() method to fix race conditions detected by `go build -race'.  Resolves https://github.com/mesos/mesos-go/issues/184.

FWIW the unit-tests look good:
```
~/go/src/github.com/mesos/mesos-go$ go test -race ./...
?   	github.com/mesos/mesos-go/auth	[no test files]
?   	github.com/mesos/mesos-go/auth/callback	[no test files]
ok  	github.com/mesos/mesos-go/auth/sasl	2.041s
?   	github.com/mesos/mesos-go/auth/sasl/mech	[no test files]
?   	github.com/mesos/mesos-go/auth/sasl/mech/crammd5	[no test files]
ok  	github.com/mesos/mesos-go/detector	2.555s
ok  	github.com/mesos/mesos-go/detector/zoo	1.174s
?   	github.com/mesos/mesos-go/examples/executor	[no test files]
?   	github.com/mesos/mesos-go/examples/scheduler	[no test files]
?   	github.com/mesos/mesos-go/examples/zkdetect	[no test files]
ok  	github.com/mesos/mesos-go/executor	13.439s
ok  	github.com/mesos/mesos-go/healthchecker	9.531s
?   	github.com/mesos/mesos-go/mesos	[no test files]
ok  	github.com/mesos/mesos-go/mesosproto	13.566s
ok  	github.com/mesos/mesos-go/mesosutil	1.032s
?   	github.com/mesos/mesos-go/mesosutil/process	[no test files]
ok  	github.com/mesos/mesos-go/messenger	13.083s
?   	github.com/mesos/mesos-go/messenger/testmessage	[no test files]
ok  	github.com/mesos/mesos-go/scheduler	19.560s
?   	github.com/mesos/mesos-go/testutil	[no test files]
ok  	github.com/mesos/mesos-go/upid	8.196s
~/go/src/github.com/mesos/mesos-go$ echo $?
0
```