### PR TITLE
fix racy UPID access and intermittent scheduler deadlock at shutdown time

### DIFF
--- a/auth/sasl/authenticatee.go
+++ b/auth/sasl/authenticatee.go
@@ -77,7 +77,7 @@ func init() {
 				log.Fatal("expected to have a parent UPID in context")
 			}
 			process := process.New("sasl_authenticatee")
-			tpid := &upid.UPID{
+			tpid := upid.UPID{
 				ID:   process.Label(),
 				Host: parent.Host,
 			}

--- a/auth/sasl/authenticatee_test.go
+++ b/auth/sasl/authenticatee_test.go
@@ -60,7 +60,7 @@ func TestAuthticatee_validLogin(t *testing.T) {
 	factory := transportFactoryFunc(func() messenger.Messenger {
 		transport = &MockTransport{messenger.NewMockedMessenger()}
 		transport.On("Install").Return(nil)
-		transport.On("UPID").Return(&tpid)
+		transport.On("UPID").Return(tpid)
 		transport.On("Start").Return(nil)
 		transport.On("Stop").Return(nil)
 

--- a/examples/Godeps/Godeps.json
+++ b/examples/Godeps/Godeps.json
@@ -7,7 +7,8 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Rev": "8edb24c179ed858a38f18920d9005c2dde05ec17"
+			"Comment": "v0.1-55-g2093b57",
+			"Rev": "2093b57e5ca2ccbee4626814100bc1aada691b18"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/all_test.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/all_test.go
@@ -401,17 +401,18 @@ type fakeMarshaler struct {
 	err error
 }
 
-func (f fakeMarshaler) Marshal() ([]byte, error) {
-	return f.b, f.err
+func (f *fakeMarshaler) Marshal() ([]byte, error) { return f.b, f.err }
+func (f *fakeMarshaler) String() string           { return fmt.Sprintf("Bytes: %v Error: %v", f.b, f.err) }
+func (f *fakeMarshaler) ProtoMessage()            {}
+func (f *fakeMarshaler) Reset()                   {}
+
+type msgWithFakeMarshaler struct {
+	M *fakeMarshaler `protobuf:"bytes,1,opt,name=fake"`
 }
 
-func (f fakeMarshaler) String() string {
-	return fmt.Sprintf("Bytes: %v Error: %v", f.b, f.err)
-}
-
-func (f fakeMarshaler) ProtoMessage() {}
-
-func (f fakeMarshaler) Reset() {}
+func (m *msgWithFakeMarshaler) String() string { return CompactTextString(m) }
+func (m *msgWithFakeMarshaler) ProtoMessage()  {}
+func (m *msgWithFakeMarshaler) Reset()         {}
 
 // Simple tests for proto messages that implement the Marshaler interface.
 func TestMarshalerEncoding(t *testing.T) {
@@ -423,7 +424,7 @@ func TestMarshalerEncoding(t *testing.T) {
 	}{
 		{
 			name: "Marshaler that fails",
-			m: fakeMarshaler{
+			m: &fakeMarshaler{
 				err: errors.New("some marshal err"),
 				b:   []byte{5, 6, 7},
 			},
@@ -432,8 +433,24 @@ func TestMarshalerEncoding(t *testing.T) {
 			wantErr: errors.New("some marshal err"),
 		},
 		{
+			name: "Marshaler that fails with RequiredNotSetError",
+			m: &msgWithFakeMarshaler{
+				M: &fakeMarshaler{
+					err: &RequiredNotSetError{},
+					b:   []byte{5, 6, 7},
+				},
+			},
+			// Since there's an error that can be continued after,
+			// the buffer should be written.
+			want: []byte{
+				10, 3, // for &msgWithFakeMarshaler
+				5, 6, 7, // for &fakeMarshaler
+			},
+			wantErr: &RequiredNotSetError{},
+		},
+		{
 			name: "Marshaler that succeeds",
-			m: fakeMarshaler{
+			m: &fakeMarshaler{
 				b: []byte{0, 1, 2, 3, 4, 127, 255},
 			},
 			want:    []byte{0, 1, 2, 3, 4, 127, 255},
@@ -443,6 +460,10 @@ func TestMarshalerEncoding(t *testing.T) {
 	for _, test := range tests {
 		b := NewBuffer(nil)
 		err := b.Marshal(test.m)
+		if _, ok := err.(*RequiredNotSetError); ok {
+			// We're not in package proto, so we can only assert the type in this case.
+			err = &RequiredNotSetError{}
+		}
 		if !reflect.DeepEqual(test.wantErr, err) {
 			t.Errorf("%s: got err %v wanted %v", test.name, err, test.wantErr)
 		}
@@ -1281,7 +1302,7 @@ func TestEnum(t *testing.T) {
 // We don't care what the value actually is, just as long as it doesn't crash.
 func TestPrintingNilEnumFields(t *testing.T) {
 	pb := new(GoEnum)
-	fmt.Sprintf("%+v", pb)
+	_ = fmt.Sprintf("%+v", pb)
 }
 
 // Verify that absent required fields cause Marshal/Unmarshal to return errors.
@@ -1934,6 +1955,58 @@ func TestMapFieldWithNil(t *testing.T) {
 	b, err := Marshal(m)
 	if err == nil {
 		t.Fatalf("Marshal of bad map should have failed, got these bytes: %v", b)
+	}
+}
+
+func TestOneof(t *testing.T) {
+	m := &Communique{}
+	b, err := Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal of empty message with oneof: %v", err)
+	}
+	if len(b) != 0 {
+		t.Errorf("Marshal of empty message yielded too many bytes: %v", b)
+	}
+
+	m = &Communique{
+		Union: &Communique_Name{"Barry"},
+	}
+
+	// Round-trip.
+	b, err = Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal of message with oneof: %v", err)
+	}
+	if len(b) != 7 { // name tag/wire (1) + name len (1) + name (5)
+		t.Errorf("Incorrect marshal of message with oneof: %v", b)
+	}
+	m.Reset()
+	if err := Unmarshal(b, m); err != nil {
+		t.Fatalf("Unmarshal of message with oneof: %v", err)
+	}
+	if x, ok := m.Union.(*Communique_Name); !ok || x.Name != "Barry" {
+		t.Errorf("After round trip, Union = %+v", m.Union)
+	}
+	if name := m.GetName(); name != "Barry" {
+		t.Errorf("After round trip, GetName = %q, want %q", name, "Barry")
+	}
+
+	// Let's try with a message in the oneof.
+	m.Union = &Communique_Msg{&Strings{StringField: String("deep deep string")}}
+	b, err = Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal of message with oneof set to message: %v", err)
+	}
+	if len(b) != 20 { // msg tag/wire (1) + msg len (1) + msg (1 + 1 + 16)
+		t.Errorf("Incorrect marshal of message with oneof set to message: %v", b)
+	}
+	m.Reset()
+	if err := Unmarshal(b, m); err != nil {
+		t.Fatalf("Unmarshal of message with oneof set to message: %v", err)
+	}
+	ss, ok := m.Union.(*Communique_Msg)
+	if !ok || ss.Msg.GetStringField() != "deep deep string" {
+		t.Errorf("After round trip with oneof set to message, Union = %+v", m.Union)
 	}
 }
 

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/clone.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/clone.go
@@ -125,6 +125,17 @@ func mergeAny(out, in reflect.Value, viaPtr bool, prop *Properties) {
 			return
 		}
 		out.Set(in)
+	case reflect.Interface:
+		// Probably a oneof field; copy non-nil values.
+		if in.IsNil() {
+			return
+		}
+		// Allocate destination if it is not set, or set to a different type.
+		// Otherwise we will merge as normal.
+		if out.IsNil() || out.Elem().Type() != in.Elem().Type() {
+			out.Set(reflect.New(in.Elem().Elem().Type())) // interface -> *T -> T -> new(T)
+		}
+		mergeAny(out.Elem(), in.Elem(), false, nil)
 	case reflect.Map:
 		if in.Len() == 0 {
 			return

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/clone_test.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/clone_test.go
@@ -232,6 +232,28 @@ var mergeTests = []struct {
 			Data:       []byte("texas!"),
 		},
 	},
+	// Oneof fields should merge by assignment.
+	{
+		src: &pb.Communique{
+			Union: &pb.Communique_Number{Number: 41},
+		},
+		dst: &pb.Communique{
+			Union: &pb.Communique_Name{Name: "Bobby Tables"},
+		},
+		want: &pb.Communique{
+			Union: &pb.Communique_Number{Number: 41},
+		},
+	},
+	// Oneof nil is the same as not set.
+	{
+		src: &pb.Communique{},
+		dst: &pb.Communique{
+			Union: &pb.Communique_Name{Name: "Bobby Tables"},
+		},
+		want: &pb.Communique{
+			Union: &pb.Communique_Name{Name: "Bobby Tables"},
+		},
+	},
 }
 
 func TestMerge(t *testing.T) {

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/decode.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/decode.go
@@ -46,6 +46,10 @@ import (
 // errOverflow is returned when an integer is too large to be represented.
 var errOverflow = errors.New("proto: integer overflow")
 
+// ErrInternalBadWireType is returned by generated code when an incorrect
+// wire type is encountered. It does not get returned to user code.
+var ErrInternalBadWireType = errors.New("proto: internal error: bad wiretype for oneof")
+
 // The fundamental decoders that interpret bytes on the wire.
 // Those that take integer types all return uint64 and are
 // therefore of type valueDecoder.
@@ -314,6 +318,24 @@ func UnmarshalMerge(buf []byte, pb Message) error {
 	return NewBuffer(buf).Unmarshal(pb)
 }
 
+// DecodeMessage reads a count-delimited message from the Buffer.
+func (p *Buffer) DecodeMessage(pb Message) error {
+	enc, err := p.DecodeRawBytes(false)
+	if err != nil {
+		return err
+	}
+	return NewBuffer(enc).Unmarshal(pb)
+}
+
+// DecodeGroup reads a tag-delimited group from the Buffer.
+func (p *Buffer) DecodeGroup(pb Message) error {
+	typ, base, err := getbase(pb)
+	if err != nil {
+		return err
+	}
+	return p.unmarshalType(typ.Elem(), GetProperties(typ.Elem()), true, base)
+}
+
 // Unmarshal parses the protocol buffer representation in the
 // Buffer and places the decoded result in pb.  If the struct
 // underlying pb does not match the data in the buffer, the results can be
@@ -370,15 +392,29 @@ func (o *Buffer) unmarshalType(st reflect.Type, prop *StructProperties, is_group
 			if prop.extendable {
 				if e := structPointer_Interface(base, st).(extendableProto); isExtensionField(e, int32(tag)) {
 					if err = o.skip(st, tag, wire); err == nil {
-						if ee, ok := e.(extensionsMap); ok {
+						if ee, eok := e.(extensionsMap); eok {
 							ext := ee.ExtensionMap()[int32(tag)] // may be missing
 							ext.enc = append(ext.enc, o.buf[oi:o.index]...)
 							ee.ExtensionMap()[int32(tag)] = ext
-						} else if ee, ok := e.(extensionsBytes); ok {
+						} else if ee, eok := e.(extensionsBytes); eok {
 							ext := ee.GetExtensions()
 							*ext = append(*ext, o.buf[oi:o.index]...)
 						}
 					}
+					continue
+				}
+			}
+			// Maybe it's a oneof?
+			if prop.oneofUnmarshaler != nil {
+				m := structPointer_Interface(base, st).(Message)
+				// First return value indicates whether tag is a oneof field.
+				ok, err = prop.oneofUnmarshaler(m, tag, wire, o)
+				if err == ErrInternalBadWireType {
+					// Map the error to something more descriptive.
+					// Do the formatting here to save generated code space.
+					err = fmt.Errorf("bad wiretype for oneof field in %T", m)
+				}
+				if ok {
 					continue
 				}
 			}
@@ -680,7 +716,7 @@ func (o *Buffer) dec_new_map(p *Properties, base structPointer) error {
 	oi := o.index       // index at the end of this map entry
 	o.index -= len(raw) // move buffer back to start of map entry
 
-	mptr := structPointer_Map(base, p.field, p.mtype) // *map[K]V
+	mptr := structPointer_NewAt(base, p.field, p.mtype) // *map[K]V
 	if mptr.Elem().IsNil() {
 		mptr.Elem().Set(reflect.MakeMap(mptr.Type().Elem()))
 	}

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/encode.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/encode.go
@@ -228,6 +228,20 @@ func Marshal(pb Message) ([]byte, error) {
 	return p.buf, err
 }
 
+// EncodeMessage writes the protocol buffer to the Buffer,
+// prefixed by a varint-encoded length.
+func (p *Buffer) EncodeMessage(pb Message) error {
+	t, base, err := getbase(pb)
+	if structPointer_IsNil(base) {
+		return ErrNil
+	}
+	if err == nil {
+		var state errorState
+		err = p.enc_len_struct(GetProperties(t.Elem()), base, &state)
+	}
+	return err
+}
+
 // Marshal takes the protocol buffer
 // and encodes it into the wire format, writing the result to the
 // Buffer.
@@ -318,7 +332,7 @@ func size_bool(p *Properties, base structPointer) int {
 
 func size_proto3_bool(p *Properties, base structPointer) int {
 	v := *structPointer_BoolVal(base, p.field)
-	if !v {
+	if !v && !p.oneof {
 		return 0
 	}
 	return len(p.tagcode) + 1 // each bool takes exactly one byte
@@ -361,7 +375,7 @@ func size_int32(p *Properties, base structPointer) (n int) {
 func size_proto3_int32(p *Properties, base structPointer) (n int) {
 	v := structPointer_Word32Val(base, p.field)
 	x := int32(word32Val_Get(v)) // permit sign extension to use full 64-bit range
-	if x == 0 {
+	if x == 0 && !p.oneof {
 		return 0
 	}
 	n += len(p.tagcode)
@@ -407,7 +421,7 @@ func size_uint32(p *Properties, base structPointer) (n int) {
 func size_proto3_uint32(p *Properties, base structPointer) (n int) {
 	v := structPointer_Word32Val(base, p.field)
 	x := word32Val_Get(v)
-	if x == 0 {
+	if x == 0 && !p.oneof {
 		return 0
 	}
 	n += len(p.tagcode)
@@ -452,7 +466,7 @@ func size_int64(p *Properties, base structPointer) (n int) {
 func size_proto3_int64(p *Properties, base structPointer) (n int) {
 	v := structPointer_Word64Val(base, p.field)
 	x := word64Val_Get(v)
-	if x == 0 {
+	if x == 0 && !p.oneof {
 		return 0
 	}
 	n += len(p.tagcode)
@@ -495,7 +509,7 @@ func size_string(p *Properties, base structPointer) (n int) {
 
 func size_proto3_string(p *Properties, base structPointer) (n int) {
 	v := *structPointer_StringVal(base, p.field)
-	if v == "" {
+	if v == "" && !p.oneof {
 		return 0
 	}
 	n += len(p.tagcode)
@@ -529,7 +543,7 @@ func (o *Buffer) enc_struct_message(p *Properties, base structPointer) error {
 		}
 		o.buf = append(o.buf, p.tagcode...)
 		o.EncodeRawBytes(data)
-		return nil
+		return state.err
 	}
 
 	o.buf = append(o.buf, p.tagcode...)
@@ -667,7 +681,7 @@ func (o *Buffer) enc_proto3_slice_byte(p *Properties, base structPointer) error 
 
 func size_slice_byte(p *Properties, base structPointer) (n int) {
 	s := *structPointer_Bytes(base, p.field)
-	if s == nil {
+	if s == nil && !p.oneof {
 		return 0
 	}
 	n += len(p.tagcode)
@@ -677,7 +691,7 @@ func size_slice_byte(p *Properties, base structPointer) (n int) {
 
 func size_proto3_slice_byte(p *Properties, base structPointer) (n int) {
 	s := *structPointer_Bytes(base, p.field)
-	if len(s) == 0 {
+	if len(s) == 0 && !p.oneof {
 		return 0
 	}
 	n += len(p.tagcode)
@@ -1084,7 +1098,7 @@ func (o *Buffer) enc_new_map(p *Properties, base structPointer) error {
 			repeated MapFieldEntry map_field = N;
 	*/
 
-	v := structPointer_Map(base, p.field, p.mtype).Elem() // map[K]V
+	v := structPointer_NewAt(base, p.field, p.mtype).Elem() // map[K]V
 	if v.Len() == 0 {
 		return nil
 	}
@@ -1123,7 +1137,7 @@ func (o *Buffer) enc_new_map(p *Properties, base structPointer) error {
 }
 
 func size_new_map(p *Properties, base structPointer) int {
-	v := structPointer_Map(base, p.field, p.mtype).Elem() // map[K]V
+	v := structPointer_NewAt(base, p.field, p.mtype).Elem() // map[K]V
 
 	keycopy, valcopy, keybase, valbase := mapEncodeScratch(p.mtype)
 
@@ -1201,6 +1215,14 @@ func (o *Buffer) enc_struct(prop *StructProperties, base structPointer) error {
 		}
 	}
 
+	// Do oneof fields.
+	if prop.oneofMarshaler != nil {
+		m := structPointer_Interface(base, prop.stype).(Message)
+		if err := prop.oneofMarshaler(m, o); err != nil {
+			return err
+		}
+	}
+
 	// Add unrecognized fields at the end.
 	if prop.unrecField.IsValid() {
 		v := *structPointer_Bytes(base, prop.unrecField)
@@ -1224,6 +1246,27 @@ func size_struct(prop *StructProperties, base structPointer) (n int) {
 	if prop.unrecField.IsValid() {
 		v := *structPointer_Bytes(base, prop.unrecField)
 		n += len(v)
+	}
+
+	// Factor in any oneof fields.
+	// TODO: This could be faster and use less reflection.
+	if prop.oneofMarshaler != nil {
+		sv := reflect.ValueOf(structPointer_Interface(base, prop.stype)).Elem()
+		for i := 0; i < prop.stype.NumField(); i++ {
+			fv := sv.Field(i)
+			if fv.Kind() != reflect.Interface || fv.IsNil() {
+				continue
+			}
+			if prop.stype.Field(i).Tag.Get("protobuf_oneof") == "" {
+				continue
+			}
+			spv := fv.Elem()         // interface -> *T
+			sv := spv.Elem()         // *T -> T
+			sf := sv.Type().Field(0) // StructField inside T
+			var prop Properties
+			prop.Init(sf.Type, "whatever", sf.Tag.Get("protobuf"), &sf)
+			n += prop.size(&prop, toStructPointer(spv))
+		}
 	}
 
 	return

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/equal.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/equal.go
@@ -154,6 +154,17 @@ func equalAny(v1, v2 reflect.Value) bool {
 		return v1.Float() == v2.Float()
 	case reflect.Int32, reflect.Int64:
 		return v1.Int() == v2.Int()
+	case reflect.Interface:
+		// Probably a oneof field; compare the inner values.
+		n1, n2 := v1.IsNil(), v2.IsNil()
+		if n1 || n2 {
+			return n1 == n2
+		}
+		e1, e2 := v1.Elem(), v2.Elem()
+		if e1.Type() != e2.Type() {
+			return false
+		}
+		return equalAny(e1, e2)
 	case reflect.Map:
 		if v1.Len() != v2.Len() {
 			return false

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/equal_test.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/equal_test.go
@@ -180,6 +180,24 @@ var EqualTests = []struct {
 		&pb.MessageWithMap{NameMapping: map[int32]string{1: "Rob"}},
 		false,
 	},
+	{
+		"oneof same",
+		&pb.Communique{Union: &pb.Communique_Number{Number: 41}},
+		&pb.Communique{Union: &pb.Communique_Number{Number: 41}},
+		true,
+	},
+	{
+		"oneof one nil",
+		&pb.Communique{Union: &pb.Communique_Number{Number: 41}},
+		&pb.Communique{},
+		false,
+	},
+	{
+		"oneof different",
+		&pb.Communique{Union: &pb.Communique_Number{Number: 41}},
+		&pb.Communique{Union: &pb.Communique_Name{Name: "Bobby Tables"}},
+		false,
+	},
 }
 
 func TestEqual(t *testing.T) {

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/lib.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/lib.go
@@ -66,6 +66,8 @@ for a protocol buffer variable v:
 	that contain it (if any) followed by the CamelCased name of the
 	extension field itself.  HasExtension, ClearExtension, GetExtension
 	and SetExtension are functions for manipulating extensions.
+  - Oneof field sets are given a single field in their message,
+	with distinguished wrapper types for each possible field value.
   - Marshal and Unmarshal are functions to encode and decode the wire format.
 
 The simplest way to describe this is to see an example.
@@ -81,6 +83,10 @@ Given file test.proto, containing
 	  repeated int64 reps = 3;
 	  optional group OptionalGroup = 4 {
 	    required string RequiredField = 5;
+	  }
+	  oneof union {
+	    int32 number = 6;
+	    string name = 7;
 	  }
 	}
 
@@ -120,15 +126,40 @@ The resulting file, test.pb.go, is:
 	}
 
 	type Test struct {
-		Label            *string             `protobuf:"bytes,1,req,name=label" json:"label,omitempty"`
-		Type             *int32              `protobuf:"varint,2,opt,name=type,def=77" json:"type,omitempty"`
-		Reps             []int64             `protobuf:"varint,3,rep,name=reps" json:"reps,omitempty"`
-		Optionalgroup    *Test_OptionalGroup `protobuf:"group,4,opt,name=OptionalGroup" json:"optionalgroup,omitempty"`
-		XXX_unrecognized []byte              `json:"-"`
+		Label         *string             `protobuf:"bytes,1,req,name=label" json:"label,omitempty"`
+		Type          *int32              `protobuf:"varint,2,opt,name=type,def=77" json:"type,omitempty"`
+		Reps          []int64             `protobuf:"varint,3,rep,name=reps" json:"reps,omitempty"`
+		Optionalgroup *Test_OptionalGroup `protobuf:"group,4,opt,name=OptionalGroup" json:"optionalgroup,omitempty"`
+		// Types that are valid to be assigned to Union:
+		//	*Test_Number
+		//	*Test_Name
+		Union            isTest_Union `protobuf_oneof:"union"`
+		XXX_unrecognized []byte       `json:"-"`
 	}
 	func (m *Test) Reset()         { *m = Test{} }
 	func (m *Test) String() string { return proto.CompactTextString(m) }
-	func (*Test) ProtoMessage()    {}
+	func (*Test) ProtoMessage() {}
+
+	type isTest_Union interface {
+		isTest_Union()
+	}
+
+	type Test_Number struct {
+		Number int32 `protobuf:"varint,6,opt,name=number"`
+	}
+	type Test_Name struct {
+		Name string `protobuf:"bytes,7,opt,name=name"`
+	}
+
+	func (*Test_Number) isTest_Union() {}
+	func (*Test_Name) isTest_Union()   {}
+
+	func (m *Test) GetUnion() isTest_Union {
+		if m != nil {
+			return m.Union
+		}
+		return nil
+	}
 	const Default_Test_Type int32 = 77
 
 	func (m *Test) GetLabel() string {
@@ -165,6 +196,20 @@ The resulting file, test.pb.go, is:
 		return ""
 	}
 
+	func (m *Test) GetNumber() int32 {
+		if x, ok := m.GetUnion().(*Test_Number); ok {
+			return x.Number
+		}
+		return 0
+	}
+
+	func (m *Test) GetName() string {
+		if x, ok := m.GetUnion().(*Test_Name); ok {
+			return x.Name
+		}
+		return ""
+	}
+
 	func init() {
 		proto.RegisterEnum("example.FOO", FOO_name, FOO_value)
 	}
@@ -187,6 +232,7 @@ package main
 			Optionalgroup: &pb.Test_OptionalGroup{
 				RequiredField: proto.String("good bye"),
 			},
+			Union: &pb.Test_Name{"fred"},
 		}
 		data, err := proto.Marshal(test)
 		if err != nil {
@@ -201,6 +247,11 @@ package main
 		if test.GetLabel() != newTest.GetLabel() {
 			log.Fatalf("data mismatch %q != %q", test.GetLabel(), newTest.GetLabel())
 		}
+		// Use a type switch to determine which oneof was set.
+		switch u := test.Union.(type) {
+		case *pb.Test_Number: // u.Number contains the number.
+		case *pb.Test_Name: // u.Name contains the string.
+		}
 		// etc.
 	}
 */
@@ -211,6 +262,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"sort"
 	"strconv"
 	"sync"
 )
@@ -459,7 +511,6 @@ out:
 				break out
 			}
 			fmt.Printf("%3d: t=%3d fix64 %d\n", index, tag, u)
-			break
 
 		case WireVarint:
 			u, err = p.DecodeVarint()
@@ -470,19 +521,11 @@ out:
 			fmt.Printf("%3d: t=%3d varint %d\n", index, tag, u)
 
 		case WireStartGroup:
-			if err != nil {
-				fmt.Printf("%3d: t=%3d start err %v\n", index, tag, err)
-				break out
-			}
 			fmt.Printf("%3d: t=%3d start\n", index, tag)
 			depth++
 
 		case WireEndGroup:
 			depth--
-			if err != nil {
-				fmt.Printf("%3d: t=%3d end err %v\n", index, tag, err)
-				break out
-			}
 			fmt.Printf("%3d: t=%3d end\n", index, tag)
 		}
 	}
@@ -787,12 +830,39 @@ func fieldDefault(ft reflect.Type, prop *Properties) (sf *scalarField, nestedMes
 // If this turns out to be inefficient we can always consider other options,
 // such as doing a Schwartzian transform.
 
-type mapKeys []reflect.Value
+func mapKeys(vs []reflect.Value) sort.Interface {
+	s := mapKeySorter{
+		vs: vs,
+		// default Less function: textual comparison
+		less: func(a, b reflect.Value) bool {
+			return fmt.Sprint(a.Interface()) < fmt.Sprint(b.Interface())
+		},
+	}
 
-func (s mapKeys) Len() int      { return len(s) }
-func (s mapKeys) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s mapKeys) Less(i, j int) bool {
-	return fmt.Sprint(s[i].Interface()) < fmt.Sprint(s[j].Interface())
+	// Type specialization per https://developers.google.com/protocol-buffers/docs/proto#maps;
+	// numeric keys are sorted numerically.
+	if len(vs) == 0 {
+		return s
+	}
+	switch vs[0].Kind() {
+	case reflect.Int32, reflect.Int64:
+		s.less = func(a, b reflect.Value) bool { return a.Int() < b.Int() }
+	case reflect.Uint32, reflect.Uint64:
+		s.less = func(a, b reflect.Value) bool { return a.Uint() < b.Uint() }
+	}
+
+	return s
+}
+
+type mapKeySorter struct {
+	vs   []reflect.Value
+	less func(a, b reflect.Value) bool
+}
+
+func (s mapKeySorter) Len() int      { return len(s.vs) }
+func (s mapKeySorter) Swap(i, j int) { s.vs[i], s.vs[j] = s.vs[j], s.vs[i] }
+func (s mapKeySorter) Less(i, j int) bool {
+	return s.less(s.vs[i], s.vs[j])
 }
 
 // isProto3Zero reports whether v is a zero proto3 value.

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/pointer_reflect.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/pointer_reflect.go
@@ -144,8 +144,8 @@ func structPointer_ExtMap(p structPointer, f field) *map[int32]Extension {
 	return structPointer_ifield(p, f).(*map[int32]Extension)
 }
 
-// Map returns the reflect.Value for the address of a map field in the struct.
-func structPointer_Map(p structPointer, f field, typ reflect.Type) reflect.Value {
+// NewAt returns the reflect.Value for a pointer to a field in the struct.
+func structPointer_NewAt(p structPointer, f field, typ reflect.Type) reflect.Value {
 	return structPointer_field(p, f).Addr()
 }
 

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/pointer_unsafe.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/pointer_unsafe.go
@@ -130,8 +130,8 @@ func structPointer_ExtMap(p structPointer, f field) *map[int32]Extension {
 	return (*map[int32]Extension)(unsafe.Pointer(uintptr(p) + uintptr(f)))
 }
 
-// Map returns the reflect.Value for the address of a map field in the struct.
-func structPointer_Map(p structPointer, f field, typ reflect.Type) reflect.Value {
+// NewAt returns the reflect.Value for a pointer to a field in the struct.
+func structPointer_NewAt(p structPointer, f field, typ reflect.Type) reflect.Value {
 	return reflect.NewAt(typ, unsafe.Pointer(uintptr(p)+uintptr(f)))
 }
 

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/properties.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/properties.go
@@ -89,6 +89,12 @@ type decoder func(p *Buffer, prop *Properties, base structPointer) error
 // A valueDecoder decodes a single integer in a particular encoding.
 type valueDecoder func(o *Buffer) (x uint64, err error)
 
+// A oneofMarshaler does the marshaling for all oneof fields in a message.
+type oneofMarshaler func(Message, *Buffer) error
+
+// A oneofUnmarshaler does the unmarshaling for a oneof field in a message.
+type oneofUnmarshaler func(Message, int, int, *Buffer) (bool, error)
+
 // tagMap is an optimization over map[int]int for typical protocol buffer
 // use-cases. Encoded protocol buffers are often in tag order with small tag
 // numbers.
@@ -137,6 +143,21 @@ type StructProperties struct {
 	order            []int          // list of struct field numbers in tag order
 	unrecField       field          // field id of the XXX_unrecognized []byte field
 	extendable       bool           // is this an extendable proto
+
+	oneofMarshaler   oneofMarshaler
+	oneofUnmarshaler oneofUnmarshaler
+	stype            reflect.Type
+
+	// OneofTypes contains information about the oneof fields in this message.
+	// It is keyed by the original name of a field.
+	OneofTypes map[string]*OneofProperties
+}
+
+// OneofProperties represents information about a specific field in a oneof.
+type OneofProperties struct {
+	Type  reflect.Type // pointer to generated struct type for this oneof field
+	Field int          // struct field number of the containing oneof in the message
+	Prop  *Properties
 }
 
 // Implement the sorting interface so we can sort the fields in tag order, as recommended by the spec.
@@ -161,6 +182,7 @@ type Properties struct {
 	Packed   bool   // relevant for repeated primitives only
 	Enum     string // set for enum types only
 	proto3   bool   // whether this is known to be a proto3 field; set for []byte only
+	oneof    bool   // whether this is a oneof field
 
 	Default    string // default value
 	HasDefault bool   // whether an explicit default was provided
@@ -215,6 +237,9 @@ func (p *Properties) String() string {
 	}
 	if p.proto3 {
 		s += ",proto3"
+	}
+	if p.oneof {
+		s += ",oneof"
 	}
 	if len(p.Enum) > 0 {
 		s += ",enum=" + p.Enum
@@ -292,6 +317,8 @@ func (p *Properties) Parse(s string) {
 			p.Enum = f[5:]
 		case f == "proto3":
 			p.proto3 = true
+		case f == "oneof":
+			p.oneof = true
 		case strings.HasPrefix(f, "def="):
 			p.HasDefault = true
 			p.Default = f[4:] // rest of string
@@ -733,6 +760,7 @@ func getPropertiesLocked(t reflect.Type) *StructProperties {
 		if f.Name == "XXX_unrecognized" { // special case
 			prop.unrecField = toField(&f)
 		}
+		oneof := f.Tag.Get("protobuf_oneof") != "" // special case
 		prop.Prop[i] = p
 		prop.order[i] = i
 		if debug {
@@ -742,13 +770,48 @@ func getPropertiesLocked(t reflect.Type) *StructProperties {
 			}
 			print("\n")
 		}
-		if p.enc == nil && !strings.HasPrefix(f.Name, "XXX_") {
+		if p.enc == nil && !strings.HasPrefix(f.Name, "XXX_") && !oneof {
 			fmt.Fprintln(os.Stderr, "proto: no encoder for", f.Name, f.Type.String(), "[GetProperties]")
 		}
 	}
 
 	// Re-order prop.order.
 	sort.Sort(prop)
+
+	type oneofMessage interface {
+		XXX_OneofFuncs() (func(Message, *Buffer) error, func(Message, int, int, *Buffer) (bool, error), []interface{})
+	}
+	if om, ok := reflect.Zero(reflect.PtrTo(t)).Interface().(oneofMessage); ok {
+		var oots []interface{}
+		prop.oneofMarshaler, prop.oneofUnmarshaler, oots = om.XXX_OneofFuncs()
+		prop.stype = t
+
+		// Interpret oneof metadata.
+		prop.OneofTypes = make(map[string]*OneofProperties)
+		for _, oot := range oots {
+			oop := &OneofProperties{
+				Type: reflect.ValueOf(oot).Type(), // *T
+				Prop: new(Properties),
+			}
+			sft := oop.Type.Elem().Field(0)
+			oop.Prop.Name = sft.Name
+			oop.Prop.Parse(sft.Tag.Get("protobuf"))
+			// There will be exactly one interface field that
+			// this new value is assignable to.
+			for i := 0; i < t.NumField(); i++ {
+				f := t.Field(i)
+				if f.Type.Kind() != reflect.Interface {
+					continue
+				}
+				if !oop.Type.AssignableTo(f.Type) {
+					continue
+				}
+				oop.Field = i
+				break
+			}
+			prop.OneofTypes[oop.Prop.OrigName] = oop
+		}
+	}
 
 	// build required counts
 	// build tags

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/proto3_proto/proto3.pb.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/proto3_proto/proto3.pb.go
@@ -16,10 +16,14 @@ It has these top-level messages:
 package proto3_proto
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 import testdata "github.com/gogo/protobuf/proto/testdata"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 type Message_Humour int32
 

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/size_test.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/size_test.go
@@ -124,6 +124,11 @@ var SizeTests = []struct {
 	{"map field with big entry", &pb.MessageWithMap{NameMapping: map[int32]string{8: strings.Repeat("x", 125)}}},
 	{"map field with big key and val", &pb.MessageWithMap{StrToStr: map[string]string{strings.Repeat("x", 70): strings.Repeat("y", 70)}}},
 	{"map field with big numeric key", &pb.MessageWithMap{NameMapping: map[int32]string{0xf00d: "om nom nom"}}},
+
+	{"oneof not set", &pb.Communique{}},
+	{"oneof zero int32", &pb.Communique{Union: &pb.Communique_Number{Number: 0}}},
+	{"oneof int32", &pb.Communique{Union: &pb.Communique_Number{Number: 3}}},
+	{"oneof string", &pb.Communique{Union: &pb.Communique_Name{Name: "Rhythmic Fman"}}},
 }
 
 func TestSize(t *testing.T) {

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/testdata/Makefile
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/testdata/Makefile
@@ -32,6 +32,6 @@
 all:	regenerate
 
 regenerate:
-	go install github.com/gogo/protobuf/protoc-gen-gogo/version/protoc-min-version
+	go install github.com/gogo/protobuf/protoc-min-version
 	protoc-min-version --version="3.0.0" --gogo_out=. test.proto
 	

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/testdata/test.pb.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/testdata/test.pb.go
@@ -35,14 +35,17 @@ It has these top-level messages:
 	GroupNew
 	FloatingPoint
 	MessageWithMap
+	Communique
 */
 package testdata
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
 var _ = math.Inf
 
 type FOO int32
@@ -301,8 +304,8 @@ func (m *GoEnum) GetFoo() FOO {
 }
 
 type GoTestField struct {
-	Label            *string `protobuf:"bytes,1,req" json:"Label,omitempty"`
-	Type             *string `protobuf:"bytes,2,req" json:"Type,omitempty"`
+	Label            *string `protobuf:"bytes,1,req,name=Label" json:"Label,omitempty"`
+	Type             *string `protobuf:"bytes,2,req,name=Type" json:"Type,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -326,13 +329,13 @@ func (m *GoTestField) GetType() string {
 
 type GoTest struct {
 	// Some typical parameters
-	Kind  *GoTest_KIND `protobuf:"varint,1,req,enum=testdata.GoTest_KIND" json:"Kind,omitempty"`
-	Table *string      `protobuf:"bytes,2,opt" json:"Table,omitempty"`
-	Param *int32       `protobuf:"varint,3,opt" json:"Param,omitempty"`
+	Kind  *GoTest_KIND `protobuf:"varint,1,req,name=Kind,enum=testdata.GoTest_KIND" json:"Kind,omitempty"`
+	Table *string      `protobuf:"bytes,2,opt,name=Table" json:"Table,omitempty"`
+	Param *int32       `protobuf:"varint,3,opt,name=Param" json:"Param,omitempty"`
 	// Required, repeated and optional foreign fields.
-	RequiredField *GoTestField   `protobuf:"bytes,4,req" json:"RequiredField,omitempty"`
-	RepeatedField []*GoTestField `protobuf:"bytes,5,rep" json:"RepeatedField,omitempty"`
-	OptionalField *GoTestField   `protobuf:"bytes,6,opt" json:"OptionalField,omitempty"`
+	RequiredField *GoTestField   `protobuf:"bytes,4,req,name=RequiredField" json:"RequiredField,omitempty"`
+	RepeatedField []*GoTestField `protobuf:"bytes,5,rep,name=RepeatedField" json:"RepeatedField,omitempty"`
+	OptionalField *GoTestField   `protobuf:"bytes,6,opt,name=OptionalField" json:"OptionalField,omitempty"`
 	// Required fields of all basic types
 	F_BoolRequired    *bool    `protobuf:"varint,10,req,name=F_Bool_required" json:"F_Bool_required,omitempty"`
 	F_Int32Required   *int32   `protobuf:"varint,11,req,name=F_Int32_required" json:"F_Int32_required,omitempty"`
@@ -933,7 +936,7 @@ func (m *GoTest) GetOptionalgroup() *GoTest_OptionalGroup {
 
 // Required, repeated, and optional groups.
 type GoTest_RequiredGroup struct {
-	RequiredField    *string `protobuf:"bytes,71,req" json:"RequiredField,omitempty"`
+	RequiredField    *string `protobuf:"bytes,71,req,name=RequiredField" json:"RequiredField,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -949,7 +952,7 @@ func (m *GoTest_RequiredGroup) GetRequiredField() string {
 }
 
 type GoTest_RepeatedGroup struct {
-	RequiredField    *string `protobuf:"bytes,81,req" json:"RequiredField,omitempty"`
+	RequiredField    *string `protobuf:"bytes,81,req,name=RequiredField" json:"RequiredField,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -965,7 +968,7 @@ func (m *GoTest_RepeatedGroup) GetRequiredField() string {
 }
 
 type GoTest_OptionalGroup struct {
-	RequiredField    *string `protobuf:"bytes,91,req" json:"RequiredField,omitempty"`
+	RequiredField    *string `protobuf:"bytes,91,req,name=RequiredField" json:"RequiredField,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -1511,7 +1514,7 @@ func (m *Empty) String() string { return proto.CompactTextString(m) }
 func (*Empty) ProtoMessage()    {}
 
 type MessageList struct {
-	Message          []*MessageList_Message `protobuf:"group,1,rep" json:"message,omitempty"`
+	Message          []*MessageList_Message `protobuf:"group,1,rep,name=Message" json:"message,omitempty"`
 	XXX_unrecognized []byte                 `json:"-"`
 }
 
@@ -1577,24 +1580,24 @@ func (m *Strings) GetBytesField() []byte {
 type Defaults struct {
 	// Default-valued fields of all basic types.
 	// Same as GoTest, but copied here to make testing easier.
-	F_Bool    *bool           `protobuf:"varint,1,opt,def=1" json:"F_Bool,omitempty"`
-	F_Int32   *int32          `protobuf:"varint,2,opt,def=32" json:"F_Int32,omitempty"`
-	F_Int64   *int64          `protobuf:"varint,3,opt,def=64" json:"F_Int64,omitempty"`
-	F_Fixed32 *uint32         `protobuf:"fixed32,4,opt,def=320" json:"F_Fixed32,omitempty"`
-	F_Fixed64 *uint64         `protobuf:"fixed64,5,opt,def=640" json:"F_Fixed64,omitempty"`
-	F_Uint32  *uint32         `protobuf:"varint,6,opt,def=3200" json:"F_Uint32,omitempty"`
-	F_Uint64  *uint64         `protobuf:"varint,7,opt,def=6400" json:"F_Uint64,omitempty"`
-	F_Float   *float32        `protobuf:"fixed32,8,opt,def=314159" json:"F_Float,omitempty"`
-	F_Double  *float64        `protobuf:"fixed64,9,opt,def=271828" json:"F_Double,omitempty"`
-	F_String  *string         `protobuf:"bytes,10,opt,def=hello, \"world!\"\n" json:"F_String,omitempty"`
-	F_Bytes   []byte          `protobuf:"bytes,11,opt,def=Bignose" json:"F_Bytes,omitempty"`
-	F_Sint32  *int32          `protobuf:"zigzag32,12,opt,def=-32" json:"F_Sint32,omitempty"`
-	F_Sint64  *int64          `protobuf:"zigzag64,13,opt,def=-64" json:"F_Sint64,omitempty"`
-	F_Enum    *Defaults_Color `protobuf:"varint,14,opt,enum=testdata.Defaults_Color,def=1" json:"F_Enum,omitempty"`
+	F_Bool    *bool           `protobuf:"varint,1,opt,name=F_Bool,def=1" json:"F_Bool,omitempty"`
+	F_Int32   *int32          `protobuf:"varint,2,opt,name=F_Int32,def=32" json:"F_Int32,omitempty"`
+	F_Int64   *int64          `protobuf:"varint,3,opt,name=F_Int64,def=64" json:"F_Int64,omitempty"`
+	F_Fixed32 *uint32         `protobuf:"fixed32,4,opt,name=F_Fixed32,def=320" json:"F_Fixed32,omitempty"`
+	F_Fixed64 *uint64         `protobuf:"fixed64,5,opt,name=F_Fixed64,def=640" json:"F_Fixed64,omitempty"`
+	F_Uint32  *uint32         `protobuf:"varint,6,opt,name=F_Uint32,def=3200" json:"F_Uint32,omitempty"`
+	F_Uint64  *uint64         `protobuf:"varint,7,opt,name=F_Uint64,def=6400" json:"F_Uint64,omitempty"`
+	F_Float   *float32        `protobuf:"fixed32,8,opt,name=F_Float,def=314159" json:"F_Float,omitempty"`
+	F_Double  *float64        `protobuf:"fixed64,9,opt,name=F_Double,def=271828" json:"F_Double,omitempty"`
+	F_String  *string         `protobuf:"bytes,10,opt,name=F_String,def=hello, \"world!\"\n" json:"F_String,omitempty"`
+	F_Bytes   []byte          `protobuf:"bytes,11,opt,name=F_Bytes,def=Bignose" json:"F_Bytes,omitempty"`
+	F_Sint32  *int32          `protobuf:"zigzag32,12,opt,name=F_Sint32,def=-32" json:"F_Sint32,omitempty"`
+	F_Sint64  *int64          `protobuf:"zigzag64,13,opt,name=F_Sint64,def=-64" json:"F_Sint64,omitempty"`
+	F_Enum    *Defaults_Color `protobuf:"varint,14,opt,name=F_Enum,enum=testdata.Defaults_Color,def=1" json:"F_Enum,omitempty"`
 	// More fields with crazy defaults.
-	F_Pinf *float32 `protobuf:"fixed32,15,opt,def=inf" json:"F_Pinf,omitempty"`
-	F_Ninf *float32 `protobuf:"fixed32,16,opt,def=-inf" json:"F_Ninf,omitempty"`
-	F_Nan  *float32 `protobuf:"fixed32,17,opt,def=nan" json:"F_Nan,omitempty"`
+	F_Pinf *float32 `protobuf:"fixed32,15,opt,name=F_Pinf,def=inf" json:"F_Pinf,omitempty"`
+	F_Ninf *float32 `protobuf:"fixed32,16,opt,name=F_Ninf,def=-inf" json:"F_Ninf,omitempty"`
+	F_Nan  *float32 `protobuf:"fixed32,17,opt,name=F_Nan,def=nan" json:"F_Nan,omitempty"`
 	// Sub-message.
 	Sub *SubDefaults `protobuf:"bytes,18,opt,name=sub" json:"sub,omitempty"`
 	// Redundant but explicit defaults.
@@ -1859,7 +1862,7 @@ func (m *MoreRepeated) GetFixeds() []uint32 {
 }
 
 type GroupOld struct {
-	G                *GroupOld_G `protobuf:"group,101,opt" json:"g,omitempty"`
+	G                *GroupOld_G `protobuf:"group,101,opt,name=G" json:"g,omitempty"`
 	XXX_unrecognized []byte      `json:"-"`
 }
 
@@ -1891,7 +1894,7 @@ func (m *GroupOld_G) GetX() int32 {
 }
 
 type GroupNew struct {
-	G                *GroupNew_G `protobuf:"group,101,opt" json:"g,omitempty"`
+	G                *GroupNew_G `protobuf:"group,101,opt,name=G" json:"g,omitempty"`
 	XXX_unrecognized []byte      `json:"-"`
 }
 
@@ -1984,6 +1987,205 @@ func (m *MessageWithMap) GetStrToStr() map[string]string {
 		return m.StrToStr
 	}
 	return nil
+}
+
+type Communique struct {
+	MakeMeCry *bool `protobuf:"varint,1,opt,name=make_me_cry" json:"make_me_cry,omitempty"`
+	// This is a oneof, called "union".
+	//
+	// Types that are valid to be assigned to Union:
+	//	*Communique_Number
+	//	*Communique_Name
+	//	*Communique_Data
+	//	*Communique_TempC
+	//	*Communique_Col
+	//	*Communique_Msg
+	Union            isCommunique_Union `protobuf_oneof:"union"`
+	XXX_unrecognized []byte             `json:"-"`
+}
+
+func (m *Communique) Reset()         { *m = Communique{} }
+func (m *Communique) String() string { return proto.CompactTextString(m) }
+func (*Communique) ProtoMessage()    {}
+
+type isCommunique_Union interface {
+	isCommunique_Union()
+}
+
+type Communique_Number struct {
+	Number int32 `protobuf:"varint,5,opt,name=number,oneof"`
+}
+type Communique_Name struct {
+	Name string `protobuf:"bytes,6,opt,name=name,oneof"`
+}
+type Communique_Data struct {
+	Data []byte `protobuf:"bytes,7,opt,name=data,oneof"`
+}
+type Communique_TempC struct {
+	TempC float64 `protobuf:"fixed64,8,opt,name=temp_c,oneof"`
+}
+type Communique_Col struct {
+	Col MyMessage_Color `protobuf:"varint,9,opt,name=col,enum=testdata.MyMessage_Color,oneof"`
+}
+type Communique_Msg struct {
+	Msg *Strings `protobuf:"bytes,10,opt,name=msg,oneof"`
+}
+
+func (*Communique_Number) isCommunique_Union() {}
+func (*Communique_Name) isCommunique_Union()   {}
+func (*Communique_Data) isCommunique_Union()   {}
+func (*Communique_TempC) isCommunique_Union()  {}
+func (*Communique_Col) isCommunique_Union()    {}
+func (*Communique_Msg) isCommunique_Union()    {}
+
+func (m *Communique) GetUnion() isCommunique_Union {
+	if m != nil {
+		return m.Union
+	}
+	return nil
+}
+
+func (m *Communique) GetMakeMeCry() bool {
+	if m != nil && m.MakeMeCry != nil {
+		return *m.MakeMeCry
+	}
+	return false
+}
+
+func (m *Communique) GetNumber() int32 {
+	if x, ok := m.GetUnion().(*Communique_Number); ok {
+		return x.Number
+	}
+	return 0
+}
+
+func (m *Communique) GetName() string {
+	if x, ok := m.GetUnion().(*Communique_Name); ok {
+		return x.Name
+	}
+	return ""
+}
+
+func (m *Communique) GetData() []byte {
+	if x, ok := m.GetUnion().(*Communique_Data); ok {
+		return x.Data
+	}
+	return nil
+}
+
+func (m *Communique) GetTempC() float64 {
+	if x, ok := m.GetUnion().(*Communique_TempC); ok {
+		return x.TempC
+	}
+	return 0
+}
+
+func (m *Communique) GetCol() MyMessage_Color {
+	if x, ok := m.GetUnion().(*Communique_Col); ok {
+		return x.Col
+	}
+	return MyMessage_RED
+}
+
+func (m *Communique) GetMsg() *Strings {
+	if x, ok := m.GetUnion().(*Communique_Msg); ok {
+		return x.Msg
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*Communique) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), []interface{}) {
+	return _Communique_OneofMarshaler, _Communique_OneofUnmarshaler, []interface{}{
+		(*Communique_Number)(nil),
+		(*Communique_Name)(nil),
+		(*Communique_Data)(nil),
+		(*Communique_TempC)(nil),
+		(*Communique_Col)(nil),
+		(*Communique_Msg)(nil),
+	}
+}
+
+func _Communique_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*Communique)
+	// union
+	switch x := m.Union.(type) {
+	case *Communique_Number:
+		_ = b.EncodeVarint(5<<3 | proto.WireVarint)
+		_ = b.EncodeVarint(uint64(x.Number))
+	case *Communique_Name:
+		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
+		_ = b.EncodeStringBytes(x.Name)
+	case *Communique_Data:
+		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
+		_ = b.EncodeRawBytes(x.Data)
+	case *Communique_TempC:
+		_ = b.EncodeVarint(8<<3 | proto.WireFixed64)
+		_ = b.EncodeFixed64(math.Float64bits(x.TempC))
+	case *Communique_Col:
+		_ = b.EncodeVarint(9<<3 | proto.WireVarint)
+		_ = b.EncodeVarint(uint64(x.Col))
+	case *Communique_Msg:
+		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Msg); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("Communique.Union has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _Communique_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*Communique)
+	switch tag {
+	case 5: // union.number
+		if wire != proto.WireVarint {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeVarint()
+		m.Union = &Communique_Number{int32(x)}
+		return true, err
+	case 6: // union.name
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeStringBytes()
+		m.Union = &Communique_Name{x}
+		return true, err
+	case 7: // union.data
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeRawBytes(true)
+		m.Union = &Communique_Data{x}
+		return true, err
+	case 8: // union.temp_c
+		if wire != proto.WireFixed64 {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeFixed64()
+		m.Union = &Communique_TempC{math.Float64frombits(x)}
+		return true, err
+	case 9: // union.col
+		if wire != proto.WireVarint {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeVarint()
+		m.Union = &Communique_Col{MyMessage_Color(x)}
+		return true, err
+	case 10: // union.msg
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(Strings)
+		err := b.DecodeMessage(msg)
+		m.Union = &Communique_Msg{msg}
+		return true, err
+	default:
+		return false, nil
+	}
 }
 
 var E_Greeting = &proto.ExtensionDesc{

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/testdata/test.proto
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/testdata/test.proto
@@ -478,3 +478,17 @@ message MessageWithMap {
   map<bool, bytes> byte_mapping = 3;
   map<string, string> str_to_str = 4;
 }
+
+message Communique {
+  optional bool make_me_cry = 1;
+
+  // This is a oneof, called "union".
+  oneof union {
+    int32 number = 5;
+    string name = 6;
+    bytes data = 7;
+    double temp_c = 8;
+    MyMessage.Color col = 9;
+    Strings msg = 10;
+  }
+}

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text.go
@@ -42,6 +42,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -254,7 +255,7 @@ func writeStruct(w *textWriter, sv reflect.Value) error {
 		}
 		if fv.Kind() == reflect.Map {
 			// Map fields are rendered as a repeated struct with key/value fields.
-			keys := fv.MapKeys() // TODO: should we sort these for deterministic output?
+			keys := fv.MapKeys()
 			sort.Sort(mapKeys(keys))
 			for _, key := range keys {
 				val := fv.MapIndex(key)
@@ -331,6 +332,32 @@ func writeStruct(w *textWriter, sv reflect.Value) error {
 			}
 		}
 
+		if fv.Kind() == reflect.Interface {
+			// Check if it is a oneof.
+			if st.Field(i).Tag.Get("protobuf_oneof") != "" {
+				// fv is nil, or holds a pointer to generated struct.
+				// That generated struct has exactly one field,
+				// which has a protobuf struct tag.
+				if fv.IsNil() {
+					continue
+				}
+				inner := fv.Elem().Elem() // interface -> *T -> T
+				tag := inner.Type().Field(0).Tag.Get("protobuf")
+				props.Parse(tag) // Overwrite the outer props.
+				// Write the value in the oneof, not the oneof itself.
+				fv = inner.Field(0)
+
+				// Special case to cope with malformed messages gracefully:
+				// If the value in the oneof is a nil pointer, don't panic
+				// in writeAny.
+				if fv.Kind() == reflect.Ptr && fv.IsNil() {
+					// Use errors.New so writeAny won't render quotes.
+					msg := errors.New("/* nil */")
+					fv = reflect.ValueOf(&msg).Elem()
+				}
+			}
+		}
+
 		if err := writeName(w, props); err != nil {
 			return err
 		}
@@ -396,15 +423,17 @@ func writeAny(w *textWriter, v reflect.Value, props *Properties) error {
 	v = reflect.Indirect(v)
 
 	if props != nil && len(props.CustomType) > 0 {
-		var custom Marshaler = v.Interface().(Marshaler)
-		data, err := custom.Marshal()
-		if err != nil {
-			return err
+		custom, ok := v.Interface().(Marshaler)
+		if ok {
+			data, err := custom.Marshal()
+			if err != nil {
+				return err
+			}
+			if err := writeString(w, string(data)); err != nil {
+				return err
+			}
+			return nil
 		}
-		if err := writeString(w, string(data)); err != nil {
-			return err
-		}
-		return nil
 	}
 
 	// Floats have special cases.
@@ -533,8 +562,8 @@ func writeMessageSet(w *textWriter, ms *MessageSet) error {
 
 			pb := reflect.New(msd.t.Elem())
 			if err := Unmarshal(item.Message, pb.Interface().(Message)); err != nil {
-				if _, err := fmt.Fprintf(w, "/* bad message: %v */\n", err); err != nil {
-					return err
+				if _, ferr := fmt.Fprintf(w, "/* bad message: %v */\n", err); ferr != nil {
+					return ferr
 				}
 			} else {
 				if err := writeStruct(w, pb.Elem()); err != nil {
@@ -559,7 +588,7 @@ func writeMessageSet(w *textWriter, ms *MessageSet) error {
 	return nil
 }
 
-func writeUnknownStruct(w *textWriter, data []byte) (err error) {
+func writeUnknownStruct(w *textWriter, data []byte) error {
 	if !w.compact {
 		if _, err := fmt.Fprintf(w, "/* %d unknown bytes */\n", len(data)); err != nil {
 			return err
@@ -569,19 +598,19 @@ func writeUnknownStruct(w *textWriter, data []byte) (err error) {
 	for b.index < len(b.buf) {
 		x, err := b.DecodeVarint()
 		if err != nil {
-			_, err := fmt.Fprintf(w, "/* %v */\n", err)
-			return err
+			_, ferr := fmt.Fprintf(w, "/* %v */\n", err)
+			return ferr
 		}
 		wire, tag := x&7, x>>3
 		if wire == WireEndGroup {
 			w.unindent()
-			if _, err := w.Write(endBraceNewline); err != nil {
-				return err
+			if _, werr := w.Write(endBraceNewline); werr != nil {
+				return werr
 			}
 			continue
 		}
-		if _, err := fmt.Fprint(w, tag); err != nil {
-			return err
+		if _, ferr := fmt.Fprint(w, tag); ferr != nil {
+			return ferr
 		}
 		if wire != WireStartGroup {
 			if err := w.WriteByte(':'); err != nil {
@@ -619,7 +648,7 @@ func writeUnknownStruct(w *textWriter, data []byte) (err error) {
 		if err != nil {
 			return err
 		}
-		if err = w.WriteByte('\n'); err != nil {
+		if err := w.WriteByte('\n'); err != nil {
 			return err
 		}
 	}

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text_parser.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text_parser.go
@@ -390,8 +390,7 @@ func (p *textParser) missingRequiredFieldError(sv reflect.Value) *RequiredNotSet
 }
 
 // Returns the index in the struct for the named field, as well as the parsed tag properties.
-func structFieldByName(st reflect.Type, name string) (int, *Properties, bool) {
-	sprops := GetProperties(st)
+func structFieldByName(sprops *StructProperties, name string) (int, *Properties, bool) {
 	i, ok := sprops.decoderOrigNames[name]
 	if ok {
 		return i, sprops.Prop[i], true
@@ -443,7 +442,8 @@ func (p *textParser) checkForColon(props *Properties, typ reflect.Type) *ParseEr
 
 func (p *textParser) readStruct(sv reflect.Value, terminator string) error {
 	st := sv.Type()
-	reqCount := GetProperties(st).reqCount
+	sprops := GetProperties(st)
+	reqCount := sprops.reqCount
 	var reqFieldErr error
 	fieldSet := make(map[string]bool)
 	// A struct is a sequence of "name: value", terminated by one of
@@ -525,95 +525,107 @@ func (p *textParser) readStruct(sv reflect.Value, terminator string) error {
 				sl = reflect.Append(sl, ext)
 				SetExtension(ep, desc, sl.Interface())
 			}
-		} else {
-			// This is a normal, non-extension field.
-			name := tok.value
-			fi, props, ok := structFieldByName(st, name)
-			if !ok {
-				return p.errorf("unknown field name %q in %v", name, st)
+			if err := p.consumeOptionalSeparator(); err != nil {
+				return err
 			}
+			continue
+		}
 
-			dst := sv.Field(fi)
+		// This is a normal, non-extension field.
+		name := tok.value
+		var dst reflect.Value
+		fi, props, ok := structFieldByName(sprops, name)
+		if ok {
+			dst = sv.Field(fi)
+		} else if oop, ok := sprops.OneofTypes[name]; ok {
+			// It is a oneof.
+			props = oop.Prop
+			nv := reflect.New(oop.Type.Elem())
+			dst = nv.Elem().Field(0)
+			sv.Field(oop.Field).Set(nv)
+		}
+		if !dst.IsValid() {
+			return p.errorf("unknown field name %q in %v", name, st)
+		}
 
-			if dst.Kind() == reflect.Map {
-				// Consume any colon.
-				if err := p.checkForColon(props, dst.Type()); err != nil {
-					return err
-				}
-
-				// Construct the map if it doesn't already exist.
-				if dst.IsNil() {
-					dst.Set(reflect.MakeMap(dst.Type()))
-				}
-				key := reflect.New(dst.Type().Key()).Elem()
-				val := reflect.New(dst.Type().Elem()).Elem()
-
-				// The map entry should be this sequence of tokens:
-				//	< key : KEY value : VALUE >
-				// Technically the "key" and "value" could come in any order,
-				// but in practice they won't.
-
-				tok := p.next()
-				var terminator string
-				switch tok.value {
-				case "<":
-					terminator = ">"
-				case "{":
-					terminator = "}"
-				default:
-					return p.errorf("expected '{' or '<', found %q", tok.value)
-				}
-				if err := p.consumeToken("key"); err != nil {
-					return err
-				}
-				if err := p.consumeToken(":"); err != nil {
-					return err
-				}
-				if err := p.readAny(key, props.mkeyprop); err != nil {
-					return err
-				}
-				if err := p.consumeOptionalSeparator(); err != nil {
-					return err
-				}
-				if err := p.consumeToken("value"); err != nil {
-					return err
-				}
-				if err := p.checkForColon(props.mvalprop, dst.Type().Elem()); err != nil {
-					return err
-				}
-				if err := p.readAny(val, props.mvalprop); err != nil {
-					return err
-				}
-				if err := p.consumeOptionalSeparator(); err != nil {
-					return err
-				}
-				if err := p.consumeToken(terminator); err != nil {
-					return err
-				}
-
-				dst.SetMapIndex(key, val)
-				continue
-			}
-
-			// Check that it's not already set if it's not a repeated field.
-			if !props.Repeated && fieldSet[name] {
-				return p.errorf("non-repeated field %q was repeated", name)
-			}
-
-			if err := p.checkForColon(props, st.Field(fi).Type); err != nil {
+		if dst.Kind() == reflect.Map {
+			// Consume any colon.
+			if err := p.checkForColon(props, dst.Type()); err != nil {
 				return err
 			}
 
-			// Parse into the field.
-			fieldSet[name] = true
-			if err := p.readAny(dst, props); err != nil {
-				if _, ok := err.(*RequiredNotSetError); !ok {
-					return err
-				}
-				reqFieldErr = err
-			} else if props.Required {
-				reqCount--
+			// Construct the map if it doesn't already exist.
+			if dst.IsNil() {
+				dst.Set(reflect.MakeMap(dst.Type()))
 			}
+			key := reflect.New(dst.Type().Key()).Elem()
+			val := reflect.New(dst.Type().Elem()).Elem()
+
+			// The map entry should be this sequence of tokens:
+			//	< key : KEY value : VALUE >
+			// Technically the "key" and "value" could come in any order,
+			// but in practice they won't.
+
+			tok := p.next()
+			var terminator string
+			switch tok.value {
+			case "<":
+				terminator = ">"
+			case "{":
+				terminator = "}"
+			default:
+				return p.errorf("expected '{' or '<', found %q", tok.value)
+			}
+			if err := p.consumeToken("key"); err != nil {
+				return err
+			}
+			if err := p.consumeToken(":"); err != nil {
+				return err
+			}
+			if err := p.readAny(key, props.mkeyprop); err != nil {
+				return err
+			}
+			if err := p.consumeOptionalSeparator(); err != nil {
+				return err
+			}
+			if err := p.consumeToken("value"); err != nil {
+				return err
+			}
+			if err := p.checkForColon(props.mvalprop, dst.Type().Elem()); err != nil {
+				return err
+			}
+			if err := p.readAny(val, props.mvalprop); err != nil {
+				return err
+			}
+			if err := p.consumeOptionalSeparator(); err != nil {
+				return err
+			}
+			if err := p.consumeToken(terminator); err != nil {
+				return err
+			}
+
+			dst.SetMapIndex(key, val)
+			continue
+		}
+
+		// Check that it's not already set if it's not a repeated field.
+		if !props.Repeated && fieldSet[name] {
+			return p.errorf("non-repeated field %q was repeated", name)
+		}
+
+		if err := p.checkForColon(props, dst.Type()); err != nil {
+			return err
+		}
+
+		// Parse into the field.
+		fieldSet[name] = true
+		if err := p.readAny(dst, props); err != nil {
+			if _, ok := err.(*RequiredNotSetError); !ok {
+				return err
+			}
+			reqFieldErr = err
+		} else if props.Required {
+			reqCount--
 		}
 
 		if err := p.consumeOptionalSeparator(); err != nil {

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text_parser_test.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text_parser_test.go
@@ -486,6 +486,18 @@ func TestMapParsing(t *testing.T) {
 	}
 }
 
+func TestOneofParsing(t *testing.T) {
+	const in = `name:"Shrek"`
+	m := new(Communique)
+	want := &Communique{Union: &Communique_Name{"Shrek"}}
+	if err := UnmarshalText(in, m); err != nil {
+		t.Fatal(err)
+	}
+	if !Equal(m, want) {
+		t.Errorf("\n got %v\nwant %v", m, want)
+	}
+}
+
 var benchInput string
 
 func init() {

--- a/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text_test.go
+++ b/examples/Godeps/_workspace/src/github.com/gogo/protobuf/proto/text_test.go
@@ -208,6 +208,30 @@ func TestMarshalTextUnknownEnum(t *testing.T) {
 	}
 }
 
+func TestTextOneof(t *testing.T) {
+	tests := []struct {
+		m    proto.Message
+		want string
+	}{
+		// zero message
+		{&pb.Communique{}, ``},
+		// scalar field
+		{&pb.Communique{Union: &pb.Communique_Number{Number: 4}}, `number:4`},
+		// message field
+		{&pb.Communique{Union: &pb.Communique_Msg{
+			Msg: &pb.Strings{StringField: proto.String("why hello!")},
+		}}, `msg:<string_field:"why hello!" >`},
+		// bad oneof (should not panic)
+		{&pb.Communique{Union: &pb.Communique_Msg{Msg: nil}}, `msg:/* nil */`},
+	}
+	for _, test := range tests {
+		got := strings.TrimSpace(test.m.String())
+		if got != test.want {
+			t.Errorf("\n got %s\nwant %s", got, test.want)
+		}
+	}
+}
+
 func BenchmarkMarshalTextBuffered(b *testing.B) {
 	buf := new(bytes.Buffer)
 	m := newTestMessage()
@@ -421,10 +445,19 @@ func TestProto3Text(t *testing.T) {
 		{&proto3pb.Message{Name: "Rob", HeightInCm: 175}, `name:"Rob" height_in_cm:175`},
 		// empty map
 		{&pb.MessageWithMap{}, ``},
-		// non-empty map; current map format is the same as a repeated struct
+		// non-empty map; map format is the same as a repeated struct,
+		// and they are sorted by key (numerically for numeric keys).
 		{
-			&pb.MessageWithMap{NameMapping: map[int32]string{1234: "Feist"}},
-			`name_mapping:<key:1234 value:"Feist" >`,
+			&pb.MessageWithMap{NameMapping: map[int32]string{
+				-1:      "Negatory",
+				7:       "Lucky",
+				1234:    "Feist",
+				6345789: "Otis",
+			}},
+			`name_mapping:<key:-1 value:"Negatory" > ` +
+				`name_mapping:<key:7 value:"Lucky" > ` +
+				`name_mapping:<key:1234 value:"Feist" > ` +
+				`name_mapping:<key:6345789 value:"Otis" >`,
 		},
 		// map with nil value; not well-defined, but we shouldn't crash
 		{

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,6 @@
 BIN := scheduler executor zkdetect
+RACE := -race
+
 .PHONY:
 .PHONY: all $(BIN)
 
@@ -6,4 +8,4 @@ all: $(BIN)
 
 $(BIN):
 	mkdir -p _output
-	godep go build -o _output/$@ ./$@
+	godep go build $(RACE) -o _output/$@ ./$@

--- a/examples/executor/main.go
+++ b/examples/executor/main.go
@@ -116,5 +116,9 @@ func main() {
 		return
 	}
 	fmt.Println("Executor process has started and running.")
-	driver.Join()
+	_, err = driver.Join()
+	if err != nil {
+		fmt.Println("driver failed:", err)
+	}
+	fmt.Println("executor terminating")
 }

--- a/examples/scheduler/main.go
+++ b/examples/scheduler/main.go
@@ -313,5 +313,5 @@ func main() {
 	if stat, err := driver.Run(); err != nil {
 		log.Infof("Framework stopped with status %s and error: %s\n", stat.String(), err.Error())
 	}
-
+	log.Infof("framework terminating")
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -423,7 +423,8 @@ func (driver *MesosExecutorDriver) start() (mesosproto.Status, error) {
 		return driver.status, err
 	}
 
-	driver.self = driver.messenger.UPID()
+	pid := driver.messenger.UPID()
+	driver.self = &pid
 
 	// Register with slave.
 	log.V(3).Infoln("Sending Executor registration")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -92,7 +92,7 @@ func createTestExecutorDriver(t *testing.T) (
 
 	messenger := messenger.NewMockedMessenger()
 	messenger.On("Start").Return(nil)
-	messenger.On("UPID").Return(&upid.UPID{})
+	messenger.On("UPID").Return(upid.UPID{})
 	messenger.On("Send").Return(nil)
 	messenger.On("Stop").Return(nil)
 
@@ -147,7 +147,7 @@ func TestExecutorDriverStartFailedToSendRegisterMessage(t *testing.T) {
 
 	// Set expections and return values.
 	messenger.On("Start").Return(nil)
-	messenger.On("UPID").Return(&upid.UPID{})
+	messenger.On("UPID").Return(upid.UPID{})
 	messenger.On("Send").Return(fmt.Errorf("messenger failed to send"))
 	messenger.On("Stop").Return(nil)
 
@@ -172,7 +172,7 @@ func TestExecutorDriverStartSucceed(t *testing.T) {
 	messenger := messenger.NewMockedMessenger()
 	driver.messenger = messenger
 	messenger.On("Start").Return(nil)
-	messenger.On("UPID").Return(&upid.UPID{})
+	messenger.On("UPID").Return(upid.UPID{})
 	messenger.On("Send").Return(nil)
 	messenger.On("Stop").Return(nil)
 
@@ -197,7 +197,7 @@ func TestExecutorDriverRun(t *testing.T) {
 	// Set expections and return values.
 	messenger := messenger.NewMockedMessenger()
 	messenger.On("Start").Return(nil)
-	messenger.On("UPID").Return(&upid.UPID{})
+	messenger.On("UPID").Return(upid.UPID{})
 	messenger.On("Send").Return(nil)
 	messenger.On("Stop").Return(nil)
 
@@ -231,7 +231,7 @@ func TestExecutorDriverJoin(t *testing.T) {
 	// Set expections and return values.
 	messenger := messenger.NewMockedMessenger()
 	messenger.On("Start").Return(nil)
-	messenger.On("UPID").Return(&upid.UPID{})
+	messenger.On("UPID").Return(upid.UPID{})
 	messenger.On("Send").Return(nil)
 	messenger.On("Stop").Return(nil)
 

--- a/messenger/decoder.go
+++ b/messenger/decoder.go
@@ -529,10 +529,7 @@ func isGracefulTermSignal(err error) bool {
 		return true
 	}
 	if operr, ok := err.(*net.OpError); ok {
-		if operr.Op != "read" {
-			return false
-		}
-		return err == syscall.ECONNRESET
+		return operr.Op == "read" && err == syscall.ECONNRESET
 	}
 	return false
 }

--- a/messenger/http_transporter_test.go
+++ b/messenger/http_transporter_test.go
@@ -315,7 +315,7 @@ func TestProcessOneRequest(t *testing.T) {
 			Request: &http.Request{
 				Method:     "foo",
 				RequestURI: "a/z/bar",
-				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte{})),
+				Body:       ioutil.NopCloser(&bytes.Reader{}),
 			},
 		})
 		// expecting to get a 202 response since the request doesn't have libprocess headers

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -19,13 +19,11 @@
 package messenger
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"reflect"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/gogo/protobuf/proto"
 	log "github.com/golang/glog"
@@ -37,20 +35,7 @@ import (
 
 const (
 	defaultQueueSize = 1024
-	preparePeriod    = time.Second * 1
 )
-
-var (
-	sendRoutines   int
-	encodeRoutines int
-	decodeRoutines int
-)
-
-func init() {
-	flag.IntVar(&sendRoutines, "send-routines", 1, "Number of network sending routines")
-	flag.IntVar(&encodeRoutines, "encode-routines", 1, "Number of encoding routines")
-	flag.IntVar(&decodeRoutines, "decode-routines", 1, "Number of decoding routines")
-}
 
 // MessageHandler is the callback of the message. When the callback
 // is invoked, the sender's upid and the message is passed to the callback.
@@ -63,12 +48,12 @@ type Messenger interface {
 	Route(ctx context.Context, from *upid.UPID, msg proto.Message) error
 	Start() error
 	Stop() error
-	UPID() *upid.UPID
+	UPID() upid.UPID
 }
 
 // MesosMessenger is an implementation of the Messenger interface.
 type MesosMessenger struct {
-	upid              *upid.UPID
+	upid              upid.UPID
 	encodingQueue     chan *Message
 	sendingQueue      chan *Message
 	installedMessages map[string]reflect.Type
@@ -81,7 +66,7 @@ type MesosMessenger struct {
 // ForHostname creates a new default messenger (HTTP), using UPIDBindingAddress to
 // determine the binding-address used for both the UPID.Host and Transport binding address.
 func ForHostname(proc *process.Process, hostname string, bindingAddress net.IP, port uint16, publishedAddress net.IP) (Messenger, error) {
-	upid := &upid.UPID{
+	upid := upid.UPID{
 		ID:   proc.Label(),
 		Port: strconv.Itoa(int(port)),
 	}
@@ -151,17 +136,16 @@ func UPIDBindingAddress(hostname string, bindingAddress net.IP) (string, error) 
 }
 
 // NewMesosMessenger creates a new mesos messenger.
-func NewHttp(upid *upid.UPID) *MesosMessenger {
+func NewHttp(upid upid.UPID) *MesosMessenger {
 	return NewHttpWithBindingAddress(upid, nil)
 }
 
-func NewHttpWithBindingAddress(upid *upid.UPID, address net.IP) *MesosMessenger {
+func NewHttpWithBindingAddress(upid upid.UPID, address net.IP) *MesosMessenger {
 	return New(upid, NewHTTPTransporter(upid, address))
 }
 
-func New(upid *upid.UPID, t Transporter) *MesosMessenger {
+func New(upid upid.UPID, t Transporter) *MesosMessenger {
 	return &MesosMessenger{
-		upid:              upid,
 		encodingQueue:     make(chan *Message, defaultQueueSize),
 		sendingQueue:      make(chan *Message, defaultQueueSize),
 		installedMessages: make(map[string]reflect.Type),
@@ -196,7 +180,7 @@ func (m *MesosMessenger) Install(handler MessageHandler, msg proto.Message) erro
 func (m *MesosMessenger) Send(ctx context.Context, upid *upid.UPID, msg proto.Message) error {
 	if upid == nil {
 		panic("cannot sent a message to a nil pid")
-	} else if upid.Equal(m.upid) {
+	} else if *upid == m.upid {
 		return fmt.Errorf("Send the message to self")
 	}
 	name := getMessageName(msg)
@@ -214,8 +198,10 @@ func (m *MesosMessenger) Send(ctx context.Context, upid *upid.UPID, msg proto.Me
 // 1) routing internal error to callback handlers
 // 2) testing components without starting remote servers.
 func (m *MesosMessenger) Route(ctx context.Context, upid *upid.UPID, msg proto.Message) error {
-	// if destination is not self, send to outbound.
-	if !upid.Equal(m.upid) {
+	if upid == nil {
+		panic("cannot route a message to a nil pid")
+	} else if *upid != m.upid {
+		// if destination is not self, send to outbound.
 		return m.Send(ctx, upid, msg)
 	}
 
@@ -229,30 +215,29 @@ func (m *MesosMessenger) Route(ctx context.Context, upid *upid.UPID, msg proto.M
 	return m.tr.Inject(ctx, &Message{upid, name, msg, data})
 }
 
-// Start starts the messenger.
+// Start starts the messenger; expects to be called once and only once.
 func (m *MesosMessenger) Start() error {
 
 	m.stop = make(chan struct{})
-	errChan := m.tr.Start()
 
-	select {
-	case err := <-errChan:
-		log.Errorf("failed to start messenger: %v", err)
-		return err
-	case <-time.After(preparePeriod): // continue
+	pid, errChan := m.tr.Start()
+	if pid == (upid.UPID{}) {
+		err := <-errChan
+		return fmt.Errorf("failed to start messenger: %v", err)
 	}
 
-	m.upid = m.tr.UPID()
+	// the pid that we're actually bound as
+	m.upid = pid
 
-	for i := 0; i < sendRoutines; i++ {
-		go m.sendLoop()
-	}
-	for i := 0; i < encodeRoutines; i++ {
-		go m.encodeLoop()
-	}
-	for i := 0; i < decodeRoutines; i++ {
-		go m.decodeLoop()
-	}
+	go m.sendLoop()
+	go m.encodeLoop()
+	go m.decodeLoop()
+
+	// wait for a listener error or a stop signal; either way stop the messenger
+
+	// TODO(jdef) a better implementation would attempt to re-listen; need to coordinate
+	// access to m.upid in that case. probably better off with a state machine instead of
+	// what we have now.
 	go func() {
 		select {
 		case err := <-errChan:
@@ -273,21 +258,27 @@ func (m *MesosMessenger) Start() error {
 }
 
 // Stop stops the messenger and clean up all the goroutines.
-func (m *MesosMessenger) Stop() error {
-	defer m.stopOnce.Do(func() { close(m.stop) })
-	log.Info("stopping messenger..")
+func (m *MesosMessenger) Stop() (err error) {
+	m.stopOnce.Do(func() {
+		select {
+		case <-m.stop:
+		default:
+			defer close(m.stop)
+		}
 
-	//TODO(jdef) don't hardcode the graceful flag here
+		log.Info("stopping messenger..")
 
-	if err := m.tr.Stop(true); err != nil && err != errTerminal {
-		log.Errorf("failed to stop the transporter: %v\n", err)
-		return err
-	}
-	return nil
+		//TODO(jdef) don't hardcode the graceful flag here
+		if err2 := m.tr.Stop(true); err2 != nil && err2 != errTerminal {
+			log.Warningf("failed to stop the transporter: %v\n", err2)
+			err = err2
+		}
+	})
+	return
 }
 
 // UPID returns the upid of the messenger.
-func (m *MesosMessenger) UPID() *upid.UPID {
+func (m *MesosMessenger) UPID() upid.UPID {
 	return m.upid
 }
 
@@ -328,7 +319,8 @@ func (m *MesosMessenger) reportError(err error) {
 	defer cancel()
 
 	c := make(chan error, 1)
-	go func() { c <- m.Route(ctx, m.UPID(), &mesos.FrameworkErrorMessage{Message: proto.String(err.Error())}) }()
+	pid := m.upid
+	go func() { c <- m.Route(ctx, &pid, &mesos.FrameworkErrorMessage{Message: proto.String(err.Error())}) }()
 	select {
 	case <-ctx.Done():
 		<-c // wait for Route to return

--- a/messenger/messenger_test.go
+++ b/messenger/messenger_test.go
@@ -25,8 +25,6 @@ func noopHandler(*upid.UPID, proto.Message) {
 	globalWG.Done()
 }
 
-func getNewPort() int { return 0 }
-
 func shuffleMessages(queue *[]proto.Message) {
 	for i := range *queue {
 		index := rand.Intn(i + 1)
@@ -131,7 +129,7 @@ func runTestServer(b *testing.B, wg *sync.WaitGroup) *httptest.Server {
 }
 
 func TestMessengerFailToInstall(t *testing.T) {
-	m := NewHttp(&upid.UPID{ID: "mesos"})
+	m := NewHttp(upid.UPID{ID: "mesos"})
 	handler := func(from *upid.UPID, pbMsg proto.Message) {}
 	assert.NotNil(t, m)
 	assert.NoError(t, m.Install(handler, &testmessage.SmallMessage{}))
@@ -139,23 +137,17 @@ func TestMessengerFailToInstall(t *testing.T) {
 }
 
 func TestMessengerFailToSend(t *testing.T) {
-	upid, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(t, err)
-	m := NewHttp(upid)
+	m := NewHttp(upid.UPID{ID: "foo", Host: "localhost"})
 	assert.NoError(t, m.Start())
-	assert.Error(t, m.Send(context.TODO(), upid, &testmessage.SmallMessage{}))
+	self := m.UPID()
+	assert.Error(t, m.Send(context.TODO(), &self, &testmessage.SmallMessage{}))
 }
 
 func TestMessenger(t *testing.T) {
 	messages := generateMixedMessages(1000)
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(t, err)
-	upid2, err := upid.Parse(fmt.Sprintf("mesos2@localhost:%d", getNewPort()))
-	assert.NoError(t, err)
-
-	m1 := NewHttp(upid1)
-	m2 := NewHttp(upid2)
+	m1 := NewHttp(upid.UPID{ID: "mesos1", Host: "localhost"})
+	m2 := NewHttp(upid.UPID{ID: "mesos2", Host: "localhost"})
 
 	done := make(chan struct{})
 	counts := make([]int, 4)
@@ -164,10 +156,11 @@ func TestMessenger(t *testing.T) {
 
 	assert.NoError(t, m1.Start())
 	assert.NoError(t, m2.Start())
+	upid2 := m2.UPID()
 
 	go func() {
 		for _, msg := range messages {
-			assert.NoError(t, m1.Send(context.TODO(), upid2, msg))
+			assert.NoError(t, m1.Send(context.TODO(), &upid2, msg))
 		}
 	}()
 
@@ -191,20 +184,20 @@ func BenchmarkMessengerSendSmallMessage(b *testing.B) {
 	srv := runTestServer(b, wg)
 	defer srv.Close()
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
 	upid2, err := upid.Parse(fmt.Sprintf("testserver@%s", srv.Listener.Addr().String()))
-
 	assert.NoError(b, err)
 
-	m1 := NewHttp(upid1)
+	m1 := NewHttp(upid.UPID{ID: "mesos1", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m1.Send(context.TODO(), upid2, messages[i%1000])
 	}
 	wg.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendMediumMessage(b *testing.B) {
@@ -215,19 +208,20 @@ func BenchmarkMessengerSendMediumMessage(b *testing.B) {
 	srv := runTestServer(b, wg)
 	defer srv.Close()
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
 	upid2, err := upid.Parse(fmt.Sprintf("testserver@%s", srv.Listener.Addr().String()))
 	assert.NoError(b, err)
 
-	m1 := NewHttp(upid1)
+	m1 := NewHttp(upid.UPID{ID: "mesos1", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m1.Send(context.TODO(), upid2, messages[i%1000])
 	}
 	wg.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendBigMessage(b *testing.B) {
@@ -238,19 +232,20 @@ func BenchmarkMessengerSendBigMessage(b *testing.B) {
 	srv := runTestServer(b, wg)
 	defer srv.Close()
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
 	upid2, err := upid.Parse(fmt.Sprintf("testserver@%s", srv.Listener.Addr().String()))
 	assert.NoError(b, err)
 
-	m1 := NewHttp(upid1)
+	m1 := NewHttp(upid.UPID{ID: "mesos1", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m1.Send(context.TODO(), upid2, messages[i%1000])
 	}
 	wg.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendLargeMessage(b *testing.B) {
@@ -261,19 +256,20 @@ func BenchmarkMessengerSendLargeMessage(b *testing.B) {
 	srv := runTestServer(b, wg)
 	defer srv.Close()
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
 	upid2, err := upid.Parse(fmt.Sprintf("testserver@%s", srv.Listener.Addr().String()))
 	assert.NoError(b, err)
 
-	m1 := NewHttp(upid1)
+	m1 := NewHttp(upid.UPID{ID: "mesos1", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m1.Send(context.TODO(), upid2, messages[i%1000])
 	}
 	wg.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendMixedMessage(b *testing.B) {
@@ -284,19 +280,20 @@ func BenchmarkMessengerSendMixedMessage(b *testing.B) {
 	srv := runTestServer(b, wg)
 	defer srv.Close()
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
 	upid2, err := upid.Parse(fmt.Sprintf("testserver@%s", srv.Listener.Addr().String()))
 	assert.NoError(b, err)
 
-	m1 := NewHttp(upid1)
+	m1 := NewHttp(upid.UPID{ID: "mesos1", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m1.Send(context.TODO(), upid2, messages[i%1000])
 	}
 	wg.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendRecvSmallMessage(b *testing.B) {
@@ -304,23 +301,25 @@ func BenchmarkMessengerSendRecvSmallMessage(b *testing.B) {
 
 	messages := generateSmallMessages(1000)
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-	upid2, err := upid.Parse(fmt.Sprintf("mesos2@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-
-	m1 := NewHttp(upid1)
-	m2 := NewHttp(upid2)
+	m1 := NewHttp(upid.UPID{ID: "foo1", Host: "localhost"})
+	m2 := NewHttp(upid.UPID{ID: "foo2", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
+
 	assert.NoError(b, m2.Start())
+	defer m2.Stop()
+
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.SmallMessage{}))
 
-	time.Sleep(time.Second) // Avoid race on upid.
+	upid2 := m2.UPID()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m1.Send(context.TODO(), upid2, messages[i%1000])
+		m1.Send(context.TODO(), &upid2, messages[i%1000])
 	}
 	globalWG.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendRecvMediumMessage(b *testing.B) {
@@ -328,23 +327,25 @@ func BenchmarkMessengerSendRecvMediumMessage(b *testing.B) {
 
 	messages := generateMediumMessages(1000)
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-	upid2, err := upid.Parse(fmt.Sprintf("mesos2@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-
-	m1 := NewHttp(upid1)
-	m2 := NewHttp(upid2)
+	m1 := NewHttp(upid.UPID{ID: "foo1", Host: "localhost"})
+	m2 := NewHttp(upid.UPID{ID: "foo2", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
+
 	assert.NoError(b, m2.Start())
+	defer m2.Stop()
+
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.MediumMessage{}))
 
-	time.Sleep(time.Second) // Avoid race on upid.
+	upid2 := m2.UPID()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m1.Send(context.TODO(), upid2, messages[i%1000])
+		m1.Send(context.TODO(), &upid2, messages[i%1000])
 	}
 	globalWG.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendRecvBigMessage(b *testing.B) {
@@ -352,72 +353,78 @@ func BenchmarkMessengerSendRecvBigMessage(b *testing.B) {
 
 	messages := generateBigMessages(1000)
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-	upid2, err := upid.Parse(fmt.Sprintf("mesos2@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-
-	m1 := NewHttp(upid1)
-	m2 := NewHttp(upid2)
+	m1 := NewHttp(upid.UPID{ID: "foo1", Host: "localhost"})
+	m2 := NewHttp(upid.UPID{ID: "foo2", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
+
 	assert.NoError(b, m2.Start())
+	defer m2.Stop()
+
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.BigMessage{}))
 
-	time.Sleep(time.Second) // Avoid race on upid.
+	upid2 := m2.UPID()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m1.Send(context.TODO(), upid2, messages[i%1000])
+		m1.Send(context.TODO(), &upid2, messages[i%1000])
 	}
 	globalWG.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendRecvLargeMessage(b *testing.B) {
 	globalWG.Add(b.N)
 	messages := generateLargeMessages(1000)
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-	upid2, err := upid.Parse(fmt.Sprintf("mesos2@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-
-	m1 := NewHttp(upid1)
-	m2 := NewHttp(upid2)
+	m1 := NewHttp(upid.UPID{ID: "foo1", Host: "localhost"})
+	m2 := NewHttp(upid.UPID{ID: "foo2", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
+
 	assert.NoError(b, m2.Start())
+	defer m2.Stop()
+
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.LargeMessage{}))
 
-	time.Sleep(time.Second) // Avoid race on upid.
+	upid2 := m2.UPID()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m1.Send(context.TODO(), upid2, messages[i%1000])
+		m1.Send(context.TODO(), &upid2, messages[i%1000])
 	}
 	globalWG.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func BenchmarkMessengerSendRecvMixedMessage(b *testing.B) {
 	globalWG.Add(b.N)
 	messages := generateMixedMessages(1000)
 
-	upid1, err := upid.Parse(fmt.Sprintf("mesos1@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-	upid2, err := upid.Parse(fmt.Sprintf("mesos2@localhost:%d", getNewPort()))
-	assert.NoError(b, err)
-
-	m1 := NewHttp(upid1)
-	m2 := NewHttp(upid2)
+	m1 := NewHttp(upid.UPID{ID: "foo1", Host: "localhost"})
+	m2 := NewHttp(upid.UPID{ID: "foo2", Host: "localhost"})
 	assert.NoError(b, m1.Start())
+	defer m1.Stop()
+
 	assert.NoError(b, m2.Start())
+	defer m2.Stop()
+
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.SmallMessage{}))
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.MediumMessage{}))
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.BigMessage{}))
 	assert.NoError(b, m2.Install(noopHandler, &testmessage.LargeMessage{}))
 
-	time.Sleep(time.Second) // Avoid race on upid.
+	upid2 := m2.UPID()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m1.Send(context.TODO(), upid2, messages[i%1000])
+		m1.Send(context.TODO(), &upid2, messages[i%1000])
 	}
 	globalWG.Wait()
+	b.StopTimer()
+	time.Sleep(2 * time.Second) // allow time for connection cleanup
 }
 
 func TestUPIDBindingAddress(t *testing.T) {

--- a/messenger/mocked_messenger.go
+++ b/messenger/mocked_messenger.go
@@ -83,8 +83,8 @@ func (m *MockedMessenger) Stop() error {
 }
 
 // UPID is a mocked implementation.
-func (m *MockedMessenger) UPID() *upid.UPID {
-	return m.Called().Get(0).(*upid.UPID)
+func (m *MockedMessenger) UPID() upid.UPID {
+	return m.Called().Get(0).(upid.UPID)
 }
 
 func (m *MockedMessenger) recvLoop() {

--- a/messenger/transporter.go
+++ b/messenger/transporter.go
@@ -43,11 +43,11 @@ type Transporter interface {
 
 	//Start starts the transporter and returns immediately. The error chan
 	//is never nil.
-	Start() <-chan error
+	Start() (upid.UPID, <-chan error)
 
 	//Stop kills the transporter.
 	Stop(graceful bool) error
 
 	//UPID returns the PID for transporter.
-	UPID() *upid.UPID
+	UPID() upid.UPID
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -270,8 +270,10 @@ func (driver *MesosSchedulerDriver) makeWithScheduler(cs Scheduler) func(func(Sc
 			// every so often - this avoids indefinitely blocking a call to Abort().
 			driver.eventLock.Unlock()
 			schedLock.Lock()
-			defer driver.eventLock.Lock()
-			defer schedLock.Unlock()
+			defer func() {
+				schedLock.Unlock()
+				driver.eventLock.Lock()
+			}()
 
 			if atomic.LoadInt32(&abort) == 1 {
 				// can't send anymore

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os/user"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -133,8 +134,8 @@ type MesosSchedulerDriver struct {
 	dispatch        func(context.Context, *upid.UPID, proto.Message) error // send a message somewhere
 	started         chan struct{}                                          // signal chan that closes upon a successful call to Start()
 	eventLock       sync.RWMutex                                           // guard for all driver state
-	eventCond       *sync.Cond                                             // linked to eventLock, used to detect driver stop
 	withScheduler   func(f func(s Scheduler))                              // execute some func with respect to the given scheduler
+	done            chan struct{}                                          // signal chan that closes when no more events will be processed
 }
 
 // Create a new mesos scheduler driver with the given
@@ -186,39 +187,10 @@ func NewMesosSchedulerDriver(config DriverConfig) (initializedDriver *MesosSched
 		failover:        framework.Id != nil && len(framework.Id.GetValue()) > 0,
 		withAuthContext: config.WithAuthContext,
 		started:         make(chan struct{}),
+		done:            make(chan struct{}),
 	}
-	driver.eventCond = sync.NewCond(&driver.eventLock)
 
-	// mechanism that allows us to asynchronously invoke scheduler callbacks, but in a manner
-	// such that the callback invocations are serialized. useful because this will decouple the
-	// goroutine executing a messenger callback from the goroutine executing a scheduler callback,
-	// while preserving the serialization semantics for each type of callback handling.
-	// we use a chan to maintain the order of callback invocations; this is important for maintaining
-	// the order in which status updates are processed.
-	schedQueue := make(chan func(s Scheduler))
-	go func() {
-		for {
-			select {
-			case f := <-schedQueue:
-				f(config.Scheduler)
-			case <-driver.stopCh:
-				// check for a tie: abort() may have sent a message that we need to pass up
-				// to the user.
-				select {
-				case f := <-schedQueue:
-					f(config.Scheduler)
-				default:
-				}
-				return
-			}
-		}
-	}()
-	driver.withScheduler = func(f func(s Scheduler)) {
-		select {
-		case schedQueue <- f:
-		case <-driver.stopCh:
-		}
-	}
+	driver.withScheduler = driver.makeWithScheduler(config.Scheduler)
 
 	if framework.FailoverTimeout != nil && *framework.FailoverTimeout > 0 {
 		driver.failoverTimeout = *framework.FailoverTimeout * float64(time.Second)
@@ -244,6 +216,71 @@ func NewMesosSchedulerDriver(config DriverConfig) (initializedDriver *MesosSched
 		initializedDriver = driver
 	}
 	return
+}
+
+func (driver *MesosSchedulerDriver) makeWithScheduler(cs Scheduler) func(func(Scheduler)) {
+	// mechanism that allows us to asynchronously invoke scheduler callbacks, but in a manner
+	// such that the callback invocations are serialized. useful because this will decouple the
+	// goroutine executing a messenger callback from the goroutine executing a scheduler callback,
+	// while preserving the serialization semantics for each type of callback handling.
+	// we use a chan to maintain the order of callback invocations; this is important for maintaining
+	// the order in which status updates are processed.
+	schedQueue := make(chan func(s Scheduler))
+	go func() {
+		defer close(driver.done)
+		for f := range schedQueue {
+			f(cs)
+		}
+	}()
+
+	var schedLock sync.Mutex // synchronize write access to schedQueue
+	abort := int32(0)
+
+	// assume that when withScheduler is invoked eventLock is locked
+	return func(f func(s Scheduler)) {
+		const timeout = 1 * time.Second
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+
+		trySend := func() (done bool) {
+			// don't block while attempting to enqueue a scheduler op; this could
+			// take a while depending upon the external scheduler implementation.
+			// also, it allows for multiple go-routines to re-compete for the lock
+			// every so often - this avoids indefinitely blocking a call to Abort().
+			driver.eventLock.Unlock()
+			schedLock.Lock()
+			defer driver.eventLock.Lock()
+			defer schedLock.Unlock()
+
+			if atomic.LoadInt32(&abort) == 1 {
+				// can't send anymore
+				return true
+			}
+			select {
+			case schedQueue <- f:
+				done = true
+			case <-driver.stopCh:
+				done = true
+				if atomic.CompareAndSwapInt32(&abort, 0, 1) {
+					// one last attempt..
+					defer close(schedQueue)
+					select {
+					case schedQueue <- f:
+					case <-t.C:
+					}
+				}
+			case <-t.C:
+			}
+			return
+		}
+		for !trySend() {
+			t.Reset(timeout) // TODO(jdef) add jitter to this
+		}
+		// have to do this outside trySend because here we're guarded by eventLock
+		if atomic.LoadInt32(&abort) == 1 {
+			driver.withScheduler = func(f func(_ Scheduler)) {}
+		}
+	}
 }
 
 // init initializes the driver.
@@ -354,7 +391,8 @@ func (driver *MesosSchedulerDriver) tryAuthentication() {
 				result.Completed = proto.Bool(true)
 				result.Success = proto.Bool(true)
 			}
-			driver.messenger.Route(context.TODO(), driver.messenger.UPID(), result)
+			pid := driver.messenger.UPID()
+			driver.messenger.Route(context.TODO(), &pid, result)
 		}()
 		driver.authenticating = authenticating
 	} else {
@@ -728,24 +766,10 @@ func (driver *MesosSchedulerDriver) start() (mesos.Status, error) {
 		return driver.status, err
 	}
 
-	driver.self = driver.messenger.UPID()
+	pid := driver.messenger.UPID()
+	driver.self = &pid
 	driver.status = mesos.Status_DRIVER_RUNNING
 	close(driver.started)
-
-	// TODO(jdef) hacky but we don't want to miss it if the scheduler shuts down
-	go func() {
-		t := time.NewTicker(2 * time.Second)
-		defer t.Stop()
-		for {
-			<-t.C
-			driver.eventCond.Broadcast()
-			select {
-			case <-driver.stopCh:
-				return
-			default:
-			}
-		}
-	}()
 
 	log.Infof("Mesos scheduler driver started with PID=%v", driver.self)
 
@@ -820,10 +844,13 @@ func (driver *MesosSchedulerDriver) doReliableRegistration(maxBackoff float64) {
 
 		log.V(1).Infof("will retry registration in %v if necessary", delay)
 
+		t := time.NewTimer(delay)
+		defer t.Stop()
+
 		select {
 		case <-driver.stopCh:
 			return
-		case <-time.After(delay):
+		case <-t.C:
 			maxBackoff *= 2
 		}
 	}
@@ -887,18 +914,31 @@ func (driver *MesosSchedulerDriver) Join() (mesos.Status, error) {
 }
 
 // join expects to be guarded by eventLock
-func (driver *MesosSchedulerDriver) join() (mesos.Status, error) {
-	if stat := driver.status; stat != mesos.Status_DRIVER_RUNNING {
-		return stat, fmt.Errorf("Unable to Join, expecting driver status %s, but is %s", mesos.Status_DRIVER_RUNNING, stat)
+func (driver *MesosSchedulerDriver) join() (stat mesos.Status, err error) {
+	if stat = driver.status; stat != mesos.Status_DRIVER_RUNNING {
+		err = fmt.Errorf("Unable to Join, expecting driver status %s, but is %s", mesos.Status_DRIVER_RUNNING, stat)
+		return
 	}
+
+	timeout := 1 * time.Second
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+
+	driver.eventLock.Unlock()
+	defer func() {
+		driver.eventLock.Lock()
+		stat = driver.status
+	}()
+waitForDeath:
 	for {
 		select {
-		case <-driver.stopCh: // wait for stop signal
-			return driver.status, nil
-		default:
-			driver.eventCond.Wait()
+		case <-driver.done:
+			break waitForDeath
+		case <-t.C:
 		}
+		t.Reset(timeout)
 	}
+	return
 }
 
 //Run starts and joins driver process and waits to be stopped or aborted.
@@ -948,27 +988,32 @@ func (driver *MesosSchedulerDriver) stop(failover bool) (mesos.Status, error) {
 		// immediately afterward the messenger is stopped in driver._stop(). so the unregister message
 		// may not actually end up being sent out.
 		if err := driver.send(driver.masterPid, message); err != nil {
-			log.Errorf("Failed to send UnregisterFramework message while stopping driver: %v\n", err)
-			return driver._stop(mesos.Status_DRIVER_ABORTED)
+			return driver._stop(fmt.Sprintf("Failed to send UnregisterFramework message while stopping driver: %v\n", err), mesos.Status_DRIVER_ABORTED)
 		}
 		time.Sleep(2 * time.Second)
 	}
 
 	// stop messenger
-	return driver._stop(mesos.Status_DRIVER_STOPPED)
+	return driver._stop("", mesos.Status_DRIVER_STOPPED)
 }
 
 // stop expects to be guarded by eventLock
-func (driver *MesosSchedulerDriver) _stop(stopStatus mesos.Status) (mesos.Status, error) {
+func (driver *MesosSchedulerDriver) _stop(message string, stopStatus mesos.Status) (mesos.Status, error) {
 	// stop messenger
 	defer func() {
 		select {
 		case <-driver.stopCh:
-			// already closed
+			return
 		default:
-			close(driver.stopCh)
 		}
-		driver.eventCond.Broadcast()
+		close(driver.stopCh)
+		if message != "" {
+			log.V(3).Infof("Sending error '%v'", message)
+			driver.withScheduler(func(s Scheduler) { s.Error(driver, message) })
+		} else {
+			// send a noop func, withScheduler needs to see that stopCh is closed
+			driver.withScheduler(func(_ Scheduler) {})
+		}
 	}()
 	driver.status = stopStatus
 	driver.connected = false
@@ -983,14 +1028,9 @@ func (driver *MesosSchedulerDriver) Abort() (stat mesos.Status, err error) {
 }
 
 // abort expects to be guarded by eventLock
-func (driver *MesosSchedulerDriver) abort(errMessage string) (stat mesos.Status, err error) {
+func (driver *MesosSchedulerDriver) abort(_ string) (stat mesos.Status, err error) {
 	defer driver.masterDetector.Cancel()
 	log.Infof("Aborting framework [%+v]", driver.frameworkInfo.Id)
-
-	if errMessage != "" {
-		log.V(3).Infof("Sending error '%v'", errMessage)
-		driver.withScheduler(func(s Scheduler) { s.Error(driver, errMessage) })
-	}
 
 	if driver.connected {
 		_, err = driver.stop(true)
@@ -1247,6 +1287,6 @@ func (driver *MesosSchedulerDriver) error(err string) {
 		return
 	}
 
-	log.Infoln("Aborting driver, got error '", err, "'")
-	driver.abort(err)
+	log.Errorln("Aborting driver, got error '", err, "'")
+	driver.abort("")
 }

--- a/scheduler/scheduler_intgr_test.go
+++ b/scheduler/scheduler_intgr_test.go
@@ -248,8 +248,12 @@ func (s *SchedulerIntegrationTestSuite) TearDownTest() {
 	if s.server != nil {
 		s.server.Close()
 	}
-	if s.driver != nil && s.driver.Status() == mesos.Status_DRIVER_RUNNING {
+	if s.driver != nil {
 		s.driver.Abort()
+
+		// wait for all events to finish processing, otherwise we can get into a data
+		// race when the suite object is reused for the next test.
+		<-s.driver.done
 	}
 }
 

--- a/scheduler/scheduler_intgr_test.go
+++ b/scheduler/scheduler_intgr_test.go
@@ -37,9 +37,10 @@ import (
 
 // testScuduler is used for testing Schduler callbacks.
 type testScheduler struct {
-	ch chan bool
-	wg *sync.WaitGroup
-	s  *SchedulerIntegrationTestSuite
+	ch     chan bool
+	wg     *sync.WaitGroup
+	s      *SchedulerIntegrationTestSuite
+	errors chan string // yields errors received by Scheduler.Error
 }
 
 // convenience
@@ -109,7 +110,7 @@ func (sched *testScheduler) ExecutorLost(SchedulerDriver, *mesos.ExecutorID, *me
 
 func (sched *testScheduler) Error(dr SchedulerDriver, err string) {
 	log.Infoln("Sched.Error() called.")
-	sched.s.Equal("test-error-999", err)
+	sched.errors <- err
 	sched.ch <- true
 }
 
@@ -128,7 +129,7 @@ func (sched *testScheduler) waitForCallback(timeout time.Duration) bool {
 }
 
 func newTestScheduler(s *SchedulerIntegrationTestSuite) *testScheduler {
-	return &testScheduler{ch: make(chan bool), s: s}
+	return &testScheduler{ch: make(chan bool), s: s, errors: make(chan string, 2)}
 }
 
 type mockServerConfigurator func(frameworkId *mesos.FrameworkID, suite *SchedulerIntegrationTestSuite)
@@ -168,8 +169,12 @@ func (suite *SchedulerIntegrationTestSuite) configure(frameworkId *mesos.Framewo
 	suite.sched = newTestScheduler(suite)
 	suite.sched.ch = make(chan bool, 10) // big enough that it doesn't block callback processing
 
-	suite.driver = newTestSchedulerDriver(suite.T(), driverConfig(suite.sched, suite.framework, suite.server.Addr, nil)).MesosSchedulerDriver
-
+	cfg := DriverConfig{
+		Scheduler: suite.sched,
+		Framework: suite.framework,
+		Master:    suite.server.Addr,
+	}
+	suite.driver = newTestSchedulerDriver(suite.T(), cfg).MesosSchedulerDriver
 	suite.config(frameworkId, suite)
 
 	stat, err := suite.driver.Start()
@@ -442,6 +447,8 @@ func (suite *SchedulerIntegrationTestSuite) TestSchedulerDriverFrameworkErrorEve
 
 	c := suite.newMockClient()
 	c.SendMessage(suite.driver.self, pbMsg)
-	suite.sched.waitForCallback(0)
+	message := <-suite.sched.errors
+	suite.Equal("test-error-999", message)
+	suite.sched.waitForCallback(10 * time.Second)
 	suite.Equal(mesos.Status_DRIVER_ABORTED, suite.driver.Status())
 }

--- a/scheduler/scheduler_unit_test.go
+++ b/scheduler/scheduler_unit_test.go
@@ -137,7 +137,7 @@ func driverConfigMessenger(sched Scheduler, framework *mesos.FrameworkInfo, mast
 func mockedMessenger() *messenger.MockedMessenger {
 	m := messenger.NewMockedMessenger()
 	m.On("Start").Return(nil)
-	m.On("UPID").Return(&upid.UPID{})
+	m.On("UPID").Return(upid.UPID{})
 	m.On("Send").Return(nil)
 	m.On("Stop").Return(nil)
 	m.On("Route").Return(nil)
@@ -228,7 +228,7 @@ func (suite *SchedulerTestSuite) TestSchedulerDriverStartWithRegistrationFailure
 	// Set expections and return values.
 	messenger := messenger.NewMockedMessenger()
 	messenger.On("Start").Return(nil)
-	messenger.On("UPID").Return(&upid.UPID{})
+	messenger.On("UPID").Return(upid.UPID{})
 	messenger.On("Stop").Return(nil)
 	messenger.On("Install").Return(nil)
 


### PR DESCRIPTION
- UPID pointer sharing between transporter and messenger was awful - cleaned it up
- during integration testing, noticed that scheduler sometimes hung at shutdown - fixed that
  - the `withScheduler` construct is looking uglier and uglier, though it is somewhat contained to the factory func that builds the func; there must be a simpler solution here.
- libprocess decoder fixes
  - check for ECONNRESET for graceful connection termination
  - reading Request's should't block if shouldQuit chan is closed
- unit tests were not happy after the above changes, fixed them