### PR TITLE
correctly stop the driver in the event of an error that happens before a connection is established

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1083,7 +1083,7 @@ func (driver *MesosSchedulerDriver) abort(cause error) (stat mesos.Status, err e
 	if driver.connected {
 		_, err = driver.stop(cause, true)
 	} else {
-		driver.messenger.Stop()
+		driver._stop(cause, mesos.Status_DRIVER_ABORTED)
 	}
 
 	stat = mesos.Status_DRIVER_ABORTED

--- a/scheduler/scheduler_unit_test.go
+++ b/scheduler/scheduler_unit_test.go
@@ -374,6 +374,11 @@ type fakeErrorScheduler struct {
 }
 
 func (f *fakeErrorScheduler) Error(d SchedulerDriver, msg string) {
+	select {
+	case <-f.called:
+		return
+	default:
+	}
 	defer close(f.called)
 	f.msg = msg
 }


### PR DESCRIPTION
when disconnected, the old implementation of `abort()` didn't do the following:
* properly forward a Error() message to the framework (the `cause`)
* close driver.stopCh