### PR TITLE
gracefully handle master failover

### DIFF
--- a/auth/login.go
+++ b/auth/login.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/mesos/mesos-go/auth/callback"
 	"github.com/mesos/mesos-go/upid"
@@ -38,8 +39,14 @@ func Login(ctx context.Context, handler callback.Handler) error {
 type loginKeyType int
 
 const (
-	loginProviderNameKey loginKeyType = iota // name of login provider to use
-	parentUpidKey                            // upid.UPID of some parent process
+	// name of login provider to use
+	loginProviderNameKey loginKeyType = iota
+
+	// upid.UPID of some parent process
+	parentUpidKey
+
+	// time.Duration that limits the overall duration of an auth attempt
+	timeoutKey
 )
 
 // Return a context that inherits all values from the parent ctx and specifies
@@ -74,7 +81,20 @@ func ParentUPIDFrom(ctx context.Context) (pid upid.UPID, ok bool) {
 func ParentUPID(ctx context.Context) (upid *upid.UPID) {
 	if upid, ok := ParentUPIDFrom(ctx); ok {
 		return &upid
-	} else {
-		return nil
 	}
+	return nil
+}
+
+func TimeoutFrom(ctx context.Context) (d time.Duration, ok bool) {
+	d, ok = ctx.Value(timeoutKey).(time.Duration)
+	return
+}
+
+func Timeout(ctx context.Context) (d time.Duration) {
+	d, _ = TimeoutFrom(ctx)
+	return
+}
+
+func WithTimeout(ctx context.Context, d time.Duration) context.Context {
+	return context.WithValue(ctx, timeoutKey, d)
 }

--- a/examples/executor/main.go
+++ b/examples/executor/main.go
@@ -21,9 +21,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math/rand"
+	"time"
 
 	exec "github.com/mesos/mesos-go/executor"
 	mesos "github.com/mesos/mesos-go/mesosproto"
+)
+
+var (
+	slowTasks = flag.Bool("slow_tasks", false, "When true tasks will take several seconds before responding with TASK_FINISHED; useful for debugging failover")
 )
 
 type exampleExecutor struct {
@@ -63,18 +69,34 @@ func (exec *exampleExecutor) LaunchTask(driver exec.ExecutorDriver, taskInfo *me
 	//
 	// this is where one would perform the requested task
 	//
-
-	// finish task
-	fmt.Println("Finishing task", taskInfo.GetName())
-	finStatus := &mesos.TaskStatus{
-		TaskId: taskInfo.GetTaskId(),
-		State:  mesos.TaskState_TASK_FINISHED.Enum(),
+	finishTask := func() {
+		// finish task
+		fmt.Println("Finishing task", taskInfo.GetName())
+		finStatus := &mesos.TaskStatus{
+			TaskId: taskInfo.GetTaskId(),
+			State:  mesos.TaskState_TASK_FINISHED.Enum(),
+		}
+		if _, err := driver.SendStatusUpdate(finStatus); err != nil {
+			fmt.Println("error sending FINISHED", err)
+		}
+		fmt.Println("Task finished", taskInfo.GetName())
 	}
-	_, err = driver.SendStatusUpdate(finStatus)
-	if err != nil {
-		fmt.Println("Got error", err)
+	if *slowTasks {
+		starting := &mesos.TaskStatus{
+			TaskId: taskInfo.GetTaskId(),
+			State:  mesos.TaskState_TASK_STARTING.Enum(),
+		}
+		if _, err := driver.SendStatusUpdate(starting); err != nil {
+			fmt.Println("error sending STARTING", err)
+		}
+		delay := time.Duration(rand.Intn(90)+10) * time.Second
+		go func() {
+			time.Sleep(delay) // TODO(jdef) add jitter
+			finishTask()
+		}()
+	} else {
+		finishTask()
 	}
-	fmt.Println("Task finished", taskInfo.GetName())
 }
 
 func (exec *exampleExecutor) KillTask(exec.ExecutorDriver, *mesos.TaskID) {

--- a/examples/scheduler/main.go
+++ b/examples/scheduler/main.go
@@ -329,6 +329,8 @@ func main() {
 
 	if stat, err := driver.Run(); err != nil {
 		log.Infof("Framework stopped with status %s and error: %s\n", stat.String(), err.Error())
+		time.Sleep(2 * time.Second)
+		os.Exit(1)
 	}
 	log.Infof("framework terminating")
 }

--- a/examples/scheduler/main.go
+++ b/examples/scheduler/main.go
@@ -59,6 +59,7 @@ var (
 	mesosAuthPrincipal  = flag.String("mesos_authentication_principal", "", "Mesos authentication principal.")
 	mesosAuthSecretFile = flag.String("mesos_authentication_secret_file", "", "Mesos authentication secret file.")
 	slowLaunch          = flag.Bool("slow_launch", false, "When true the ResourceOffers func waits for several seconds before attempting to launch tasks; useful for debugging failover")
+	slowTasks           = flag.Bool("slow_tasks", false, "When true tasks will take several seconds before responding with TASK_FINISHED; useful for debugging failover")
 )
 
 type ExampleScheduler struct {
@@ -252,7 +253,7 @@ func prepareExecutorInfo() *mesos.ExecutorInfo {
 			}
 		}
 	}
-	executorCommand := fmt.Sprintf("./%s -logtostderr=true -v=%d", executorCmd, v)
+	executorCommand := fmt.Sprintf("./%s -logtostderr=true -v=%d -slow_tasks=%v", executorCmd, v, *slowTasks)
 
 	go http.ListenAndServe(fmt.Sprintf("%s:%d", *address, *artifactPort), nil)
 	log.V(2).Info("Serving executor artifacts...")

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -223,6 +223,12 @@ func (driver *MesosExecutorDriver) Connected() bool {
 
 // --------------------- Message Handlers --------------------- //
 
+// networkError is invoked when there's a network-level error communicating with the mesos slave.
+// The driver reacts by entering a "disconnected" state and invoking the Executor.Disconnected
+// callback. The assumption is that if this driver was previously connected, and then there's a
+// network error, then the slave process must be dying/dead. The native driver implementation makes
+// this same assumption. I have some concerns that this may be a false-positive in some situations;
+// some network errors (timeouts) may be indicative of something other than a dead slave process.
 func (driver *MesosExecutorDriver) networkError(ctx context.Context, from *upid.UPID, pbMsg proto.Message) {
 	if !driver.connected {
 		log.V(1).Info("ignoring network error because not connected")

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -246,9 +246,9 @@ func (driver *MesosExecutorDriver) networkError(ctx context.Context, from *upid.
 		log.V(1).Info("ignoring network error because aborted")
 		return
 	}
-	msg := pbMsg.(*mesosproto.InternalNetworkError)
 	if driver.connected {
 		driver.connected = false
+		msg := pbMsg.(*mesosproto.InternalNetworkError)
 		session := msg.GetSession()
 
 		if session != driver.connection.String() {

--- a/executor/executor_intgr_test.go
+++ b/executor/executor_intgr_test.go
@@ -112,6 +112,7 @@ func (i *integrationTestDriver) setConnected(b bool) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
 	i.connected = b
+	i.connection = uuid.NewUUID()
 }
 
 // connectionListener returns a signal chan that closes once driver.connected == true.
@@ -528,40 +529,10 @@ func TestExecutorDriverShutdownEvent(t *testing.T) {
 
 	select {
 	case <-ch:
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 20):
 		log.Errorf("Tired of waiting...")
 	}
 
 	<-time.After(time.Second * 1) // wait for shutdown to finish.
 	assert.Equal(t, mesos.Status_DRIVER_STOPPED, driver.Status())
-}
-
-func TestExecutorDriverError(t *testing.T) {
-	setTestEnv(t)
-	ch := make(chan bool, 2)
-	// Mock Slave process to respond to registration event.
-	server := testutil.NewMockSlaveHttpServer(t, func(rsp http.ResponseWriter, req *http.Request) {
-		reqPath, err := url.QueryUnescape(req.URL.String())
-		assert.NoError(t, err)
-		log.Infoln("RCVD request", reqPath)
-		rsp.WriteHeader(http.StatusAccepted)
-	})
-
-	exec := newTestExecutor(t)
-	exec.ch = ch
-	exec.t = t
-
-	driver := newIntegrationTestDriver(t, exec)
-	server.Close() // will cause error
-	// Run() cause async message processing to start
-	// Therefore, error-handling will be done via Executor.Error callaback.
-	stat, err := driver.Run()
-	assert.NoError(t, err)
-	assert.Equal(t, mesos.Status_DRIVER_STOPPED, stat)
-
-	select {
-	case <-ch:
-	case <-time.After(time.Second * 1):
-		log.Errorf("Tired of waiting...")
-	}
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -388,7 +388,7 @@ func TestStatusUpdateAckRace_Issue103(t *testing.T) {
 	go func() {
 		driver.lock.Lock()
 		defer driver.lock.Unlock()
-		driver.statusUpdateAcknowledgement(nil, msg)
+		driver.statusUpdateAcknowledgement(driver.context(), nil, msg)
 	}()
 
 	taskStatus := util.NewTaskStatus(

--- a/mesosproto/authentication.pb.go
+++ b/mesosproto/authentication.pb.go
@@ -22,6 +22,7 @@ It has these top-level messages:
 	InternalMasterChangeDetected
 	InternalTryAuthentication
 	InternalAuthenticationResult
+	InternalNetworkError
 	FrameworkID
 	OfferID
 	SlaveID

--- a/mesosproto/authenticationpb_test.go
+++ b/mesosproto/authenticationpb_test.go
@@ -22,6 +22,7 @@ It has these top-level messages:
 	InternalMasterChangeDetected
 	InternalTryAuthentication
 	InternalAuthenticationResult
+	InternalNetworkError
 	FrameworkID
 	OfferID
 	SlaveID

--- a/mesosproto/internal.pb.go
+++ b/mesosproto/internal.pb.go
@@ -75,3 +75,29 @@ func (m *InternalAuthenticationResult) GetPid() string {
 	}
 	return ""
 }
+
+type InternalNetworkError struct {
+	// master pid that this event pertains to
+	Pid *string `protobuf:"bytes,1,req,name=pid" json:"pid,omitempty"`
+	// driver session UUID
+	Session          *string `protobuf:"bytes,2,opt,name=session" json:"session,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *InternalNetworkError) Reset()         { *m = InternalNetworkError{} }
+func (m *InternalNetworkError) String() string { return proto.CompactTextString(m) }
+func (*InternalNetworkError) ProtoMessage()    {}
+
+func (m *InternalNetworkError) GetPid() string {
+	if m != nil && m.Pid != nil {
+		return *m.Pid
+	}
+	return ""
+}
+
+func (m *InternalNetworkError) GetSession() string {
+	if m != nil && m.Session != nil {
+		return *m.Session
+	}
+	return ""
+}

--- a/mesosproto/internal.proto
+++ b/mesosproto/internal.proto
@@ -21,3 +21,10 @@ message InternalAuthenticationResult {
 	// master pid that this result pertains to
 	required string pid = 3;
 }
+
+message InternalNetworkError {
+	// master pid that this event pertains to
+	required string pid = 1;
+	// driver session UUID
+	optional string session = 2;
+}

--- a/messenger/decoder.go
+++ b/messenger/decoder.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	DefaultReadTimeout  = 5 * time.Second
-	DefaultWriteTimeout = 5 * time.Second
+	DefaultReadTimeout  = 10 * time.Second
+	DefaultWriteTimeout = 10 * time.Second
 
 	// writeFlushPeriod is the amount of time we're willing to wait for a single
 	// response buffer to be fully written to the underlying TCP connection; after

--- a/messenger/decoder.go
+++ b/messenger/decoder.go
@@ -20,9 +20,6 @@ import (
 )
 
 const (
-	DefaultReadTimeout  = 10 * time.Second
-	DefaultWriteTimeout = 10 * time.Second
-
 	// writeFlushPeriod is the amount of time we're willing to wait for a single
 	// response buffer to be fully written to the underlying TCP connection; after
 	// this amount of time the remaining bytes of the response are discarded. see
@@ -43,12 +40,7 @@ func (did *decoderID) next() decoderID {
 var (
 	errHijackFailed = errors.New("failed to hijack http connection")
 	did             decoderID // decoder ID counter
-	closedChan      = make(chan struct{})
 )
-
-func init() {
-	close(closedChan)
-}
 
 type Decoder interface {
 	Requests() <-chan *Request
@@ -99,8 +91,8 @@ func DecodeHTTP(w http.ResponseWriter, r *http.Request) Decoder {
 		req:          r,
 		shouldQuit:   make(chan struct{}),
 		forceQuit:    make(chan struct{}),
-		readTimeout:  DefaultReadTimeout,
-		writeTimeout: DefaultWriteTimeout,
+		readTimeout:  ReadTimeout,
+		writeTimeout: WriteTimeout,
 		idtag:        id.String(),
 		outCh:        make(chan *bytes.Buffer),
 	}

--- a/messenger/http_transporter.go
+++ b/messenger/http_transporter.go
@@ -27,11 +27,9 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	log "github.com/golang/glog"
@@ -62,7 +60,6 @@ var (
 type httpTransporter interface {
 	Send(ctx context.Context, msg *Message) error
 	Recv() (*Message, error)
-	Inject(ctx context.Context, msg *Message) error
 	Install(messageName string)
 	Start() (upid.UPID, <-chan error)
 	Stop(graceful bool) error
@@ -80,11 +77,10 @@ type runningState struct {
 
 /* -- not-started state */
 
-func (s *notStartedState) Send(ctx context.Context, msg *Message) error   { return errNotStarted }
-func (s *notStartedState) Recv() (*Message, error)                        { return nil, errNotStarted }
-func (s *notStartedState) Inject(ctx context.Context, msg *Message) error { return errNotStarted }
-func (s *notStartedState) Stop(graceful bool) error                       { return errNotStarted }
-func (s *notStartedState) Install(messageName string)                     { s.h.install(messageName) }
+func (s *notStartedState) Send(ctx context.Context, msg *Message) error { return errNotStarted }
+func (s *notStartedState) Recv() (*Message, error)                      { return nil, errNotStarted }
+func (s *notStartedState) Stop(graceful bool) error                     { return errNotStarted }
+func (s *notStartedState) Install(messageName string)                   { s.h.install(messageName) }
 func (s *notStartedState) Start() (upid.UPID, <-chan error) {
 	s.h.state = &runningState{s}
 	return s.h.start()
@@ -92,11 +88,10 @@ func (s *notStartedState) Start() (upid.UPID, <-chan error) {
 
 /* -- stopped state */
 
-func (s *stoppedState) Send(ctx context.Context, msg *Message) error   { return errTerminal }
-func (s *stoppedState) Recv() (*Message, error)                        { return nil, errTerminal }
-func (s *stoppedState) Inject(ctx context.Context, msg *Message) error { return errTerminal }
-func (s *stoppedState) Stop(graceful bool) error                       { return errTerminal }
-func (s *stoppedState) Install(messageName string)                     {}
+func (s *stoppedState) Send(ctx context.Context, msg *Message) error { return errTerminal }
+func (s *stoppedState) Recv() (*Message, error)                      { return nil, errTerminal }
+func (s *stoppedState) Stop(graceful bool) error                     { return errTerminal }
+func (s *stoppedState) Install(messageName string)                   {}
 func (s *stoppedState) Start() (upid.UPID, <-chan error) {
 	ch := make(chan error, 1)
 	ch <- errTerminal
@@ -105,9 +100,8 @@ func (s *stoppedState) Start() (upid.UPID, <-chan error) {
 
 /* -- running state */
 
-func (s *runningState) Send(ctx context.Context, msg *Message) error   { return s.h.send(ctx, msg) }
-func (s *runningState) Recv() (*Message, error)                        { return s.h.recv() }
-func (s *runningState) Inject(ctx context.Context, msg *Message) error { return s.h.inject(ctx, msg) }
+func (s *runningState) Send(ctx context.Context, msg *Message) error { return s.h.send(ctx, msg) }
+func (s *runningState) Recv() (*Message, error)                      { return s.h.recv() }
 func (s *runningState) Stop(graceful bool) error {
 	s.h.state = &stoppedState{}
 	return s.h.stop(graceful)
@@ -155,95 +149,59 @@ func (t *HTTPTransporter) getState() httpTransporter {
 	return t.state
 }
 
-// some network errors are probably recoverable, attempt to determine that here.
-func isRecoverableError(err error) bool {
-	if urlErr, ok := err.(*url.Error); ok {
-		log.V(2).Infof("checking url.Error for recoverability")
-		return urlErr.Op == "Post" && isRecoverableError(urlErr.Err)
-	} else if netErr, ok := err.(*net.OpError); ok && netErr.Err != nil {
-		log.V(2).Infof("checking net.OpError for recoverability: %#v", err)
-		if netErr.Temporary() {
-			return true
-		}
-		//TODO(jdef) this is pretty hackish, there's probably a better way
-		//TODO(jdef) should also check for EHOSTDOWN and EHOSTUNREACH
-		return (netErr.Op == "dial" && netErr.Net == "tcp" && netErr.Err == syscall.ECONNREFUSED)
-	}
-	log.V(2).Infof("unrecoverable error: %#v", err)
-	return false
-}
-
-type recoverableError struct {
-	Err error
-}
-
-func (e *recoverableError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Err.Error()
-}
-
 // Send sends the message to its specified upid.
 func (t *HTTPTransporter) Send(ctx context.Context, msg *Message) (sendError error) {
 	return t.getState().Send(ctx, msg)
 }
 
+type mesosError struct {
+	errorCode int
+	upid      string
+	uri       string
+	status    string
+}
+
+func (e *mesosError) Error() string {
+	return fmt.Sprintf("master %s rejected %s, returned status %q",
+		e.upid, e.uri, e.status)
+}
+
+type networkError struct {
+	cause error
+}
+
+func (e *networkError) Error() string {
+	return e.cause.Error()
+}
+
+// send delivers a message to a mesos component via HTTP, returns a mesosError if the
+// connection to the component was successful but was rejected. non-mesos errors indicate
+// that the HTTP connection attempt failed for some reason.
 func (t *HTTPTransporter) send(ctx context.Context, msg *Message) (sendError error) {
 	log.V(2).Infof("Sending message to %v via http\n", msg.UPID)
 	req, err := t.makeLibprocessRequest(msg)
 	if err != nil {
-		log.Errorf("Failed to make libprocess request: %v\n", err)
 		return err
 	}
-	duration := 1 * time.Second
-	for attempt := 0; attempt < 5; attempt++ { //TODO(jdef) extract/parameterize constant
-		if sendError != nil {
-			duration *= 2
-			log.Warningf("attempting to recover from error '%v', waiting before retry: %v", sendError, duration)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(duration):
-				// ..retry request, continue
-			case <-t.shouldQuit:
-				return discardOnStopError
-			}
-		}
-		sendError = t.httpDo(ctx, req, func(resp *http.Response, err error) error {
-			if err != nil {
-				if isRecoverableError(err) {
-					return &recoverableError{Err: err}
-				}
-				log.Infof("Failed to POST: %v\n", err)
-				return err
-			}
-			defer resp.Body.Close()
 
-			// ensure master acknowledgement.
-			if (resp.StatusCode != http.StatusOK) &&
-				(resp.StatusCode != http.StatusAccepted) {
-				msg := fmt.Sprintf("Master %s rejected %s.  Returned status %s.",
-					msg.UPID, msg.RequestURI(), resp.Status)
-				log.Warning(msg)
-				return fmt.Errorf(msg)
-			}
-			return nil
-		})
-		if sendError == nil {
-			// success
-			return
-		} else if _, ok := sendError.(*recoverableError); ok {
-			// recoverable, attempt backoff?
-			continue
+	return t.httpDo(ctx, req, func(resp *http.Response, err error) error {
+		if err != nil {
+			log.V(1).Infof("Failed to POST: %v\n", err)
+			return &networkError{err}
 		}
-		// unrecoverable
-		break
-	}
-	if recoverable, ok := sendError.(*recoverableError); ok {
-		sendError = recoverable.Err
-	}
-	return
+		defer resp.Body.Close()
+
+		// ensure master acknowledgement.
+		if (resp.StatusCode != http.StatusOK) && (resp.StatusCode != http.StatusAccepted) {
+			return &mesosError{
+				errorCode: resp.StatusCode,
+				upid:      msg.UPID.String(),
+				uri:       msg.RequestURI(),
+				status:    resp.Status,
+			}
+		}
+		return nil
+	})
 }
 
 func (t *HTTPTransporter) httpDo(ctx context.Context, req *http.Request, f func(*http.Response, error) error) error {
@@ -287,30 +245,6 @@ func (t *HTTPTransporter) recv() (*Message, error) {
 	case <-t.shouldQuit:
 	}
 	return nil, discardOnStopError
-}
-
-//Inject places a message into the incoming message queue.
-func (t *HTTPTransporter) Inject(ctx context.Context, msg *Message) error {
-	return t.getState().Inject(ctx, msg)
-}
-
-func (t *HTTPTransporter) inject(ctx context.Context, msg *Message) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-t.shouldQuit:
-		return discardOnStopError
-	default: // continue
-	}
-
-	select {
-	case t.messageQueue <- msg:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-t.shouldQuit:
-		return discardOnStopError
-	}
 }
 
 // Install the request URI according to the message's name.
@@ -587,7 +521,7 @@ func (t *HTTPTransporter) makeLibprocessRequest(msg *Message) (*http.Request, er
 	log.V(2).Infof("libproc target URL %s", targetURL)
 	req, err := http.NewRequest("POST", targetURL, bytes.NewReader(msg.Bytes))
 	if err != nil {
-		log.Errorf("Failed to create request: %v\n", err)
+		log.V(1).Infof("Failed to create request: %v\n", err)
 		return nil, err
 	}
 	if !msg.isV1API() {

--- a/messenger/http_transporter.go
+++ b/messenger/http_transporter.go
@@ -175,8 +175,8 @@ func (e *networkError) Error() string {
 }
 
 // send delivers a message to a mesos component via HTTP, returns a mesosError if the
-// connection to the component was successful but was rejected. non-mesos errors indicate
-// that the HTTP connection attempt failed for some reason.
+// communication with the remote process was successful but rejected. A networkError
+// error indicates that communication with the remote process failed at the network layer.
 func (t *HTTPTransporter) send(ctx context.Context, msg *Message) (sendError error) {
 	log.V(2).Infof("Sending message to %v via http\n", msg.UPID)
 	req, err := t.makeLibprocessRequest(msg)

--- a/messenger/http_transporter_test.go
+++ b/messenger/http_transporter_test.go
@@ -185,47 +185,6 @@ func TestTransporterStartAndRcvd(t *testing.T) {
 	}
 }
 
-func TestTransporterStartAndInject(t *testing.T) {
-	serverId := "testserver"
-	protoMsg := testmessage.GenerateSmallMessage()
-	msgName := getMessageName(protoMsg)
-	ctrl := make(chan struct{})
-
-	// setup receiver (server) process
-	receiver := NewHTTPTransporter(upid.UPID{ID: serverId, Host: "127.0.0.1"}, nil)
-	receiver.Install(msgName)
-	rcvPid, errch := receiver.Start()
-	defer receiver.Stop(false)
-
-	msg := &Message{
-		UPID:         &rcvPid,
-		Name:         msgName,
-		ProtoMessage: protoMsg,
-	}
-
-	receiver.Inject(context.TODO(), msg)
-
-	go func() {
-		defer close(ctrl)
-		msg, err := receiver.Recv()
-		assert.Nil(t, err)
-		assert.NotNil(t, msg)
-		if msg != nil {
-			assert.Equal(t, msgName, msg.Name)
-		}
-	}()
-
-	select {
-	case <-time.After(time.Second * 1):
-		t.Fatalf("Timeout")
-	case <-ctrl:
-	case err := <-errch:
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
-	}
-}
-
 func TestTransporterStartAndStop(t *testing.T) {
 	serverId := "testserver"
 

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -30,6 +30,7 @@ import (
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/mesos/mesos-go/mesosproto/scheduler"
 	"github.com/mesos/mesos-go/mesosutil/process"
+	"github.com/mesos/mesos-go/messenger/sessionid"
 	"github.com/mesos/mesos-go/upid"
 	"golang.org/x/net/context"
 )
@@ -52,16 +53,19 @@ type Messenger interface {
 	UPID() upid.UPID
 }
 
+type responseFunc func(context.Context, *Message, error) error
+type dispatchFunc func(responseFunc)
+
 // MesosMessenger is an implementation of the Messenger interface.
 type MesosMessenger struct {
 	upid              upid.UPID
-	encodingQueue     chan *Message
-	sendingQueue      chan *Message
+	sendingQueue      chan dispatchFunc
 	installedMessages map[string]reflect.Type
 	installedHandlers map[string]MessageHandler
 	stop              chan struct{}
 	stopOnce          sync.Once
 	tr                Transporter
+	guardHandlers     sync.RWMutex // protect simultaneous changes to messages/handlers maps
 }
 
 // ForHostname creates a new default messenger (HTTP), using UPIDBindingAddress to
@@ -142,13 +146,12 @@ func NewHttp(upid upid.UPID) *MesosMessenger {
 }
 
 func NewHttpWithBindingAddress(upid upid.UPID, address net.IP) *MesosMessenger {
-	return New(upid, NewHTTPTransporter(upid, address))
+	return New(NewHTTPTransporter(upid, address))
 }
 
-func New(upid upid.UPID, t Transporter) *MesosMessenger {
+func New(t Transporter) *MesosMessenger {
 	return &MesosMessenger{
-		encodingQueue:     make(chan *Message, defaultQueueSize),
-		sendingQueue:      make(chan *Message, defaultQueueSize),
+		sendingQueue:      make(chan dispatchFunc, defaultQueueSize),
 		installedMessages: make(map[string]reflect.Type),
 		installedHandlers: make(map[string]MessageHandler),
 		tr:                t,
@@ -168,6 +171,10 @@ func (m *MesosMessenger) Install(handler MessageHandler, msg proto.Message) erro
 	if _, ok := m.installedMessages[name]; ok {
 		return fmt.Errorf("Message %v is already installed", name)
 	}
+
+	m.guardHandlers.Lock()
+	defer m.guardHandlers.Unlock()
+
 	m.installedMessages[name] = mtype.Elem()
 	m.installedHandlers[name] = handler
 	m.tr.Install(name)
@@ -184,12 +191,27 @@ func (m *MesosMessenger) Send(ctx context.Context, upid *upid.UPID, msg proto.Me
 	} else if *upid == m.upid {
 		return fmt.Errorf("Send the message to self")
 	}
+
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
 	name := getMessageName(msg)
 	log.V(2).Infof("Sending message %v to %v\n", name, upid)
+
+	wrapped := &Message{upid, name, msg, b}
+	d := dispatchFunc(func(rf responseFunc) {
+		err := m.tr.Send(ctx, wrapped)
+		err = rf(ctx, wrapped, err)
+		if err != nil {
+			m.reportError("send", wrapped, err)
+		}
+	})
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case m.encodingQueue <- &Message{upid, name, msg, nil}:
+	case m.sendingQueue <- d:
 		return nil
 	}
 }
@@ -206,14 +228,18 @@ func (m *MesosMessenger) Route(ctx context.Context, upid *upid.UPID, msg proto.M
 		return m.Send(ctx, upid, msg)
 	}
 
-	// TODO(jdef) this has an unfortunate performance impact for self-messaging. implement
-	// something more reasonable here.
-	data, err := proto.Marshal(msg)
-	if err != nil {
-		return err
-	}
 	name := getMessageName(msg)
-	return m.tr.Inject(ctx, &Message{upid, name, msg, data})
+	log.V(2).Infof("routing message %q to self", name)
+
+	_, handler, ok := m.messageBinding(name)
+	if !ok {
+		return fmt.Errorf("failed to route message, no message binding for %q", name)
+	}
+
+	// the implication of this is that messages can be delivered to self even if the
+	// messenger has been stopped. is that OK?
+	go handler(upid, msg)
+	return nil
 }
 
 // Start starts the messenger; expects to be called once and only once.
@@ -231,7 +257,6 @@ func (m *MesosMessenger) Start() error {
 	m.upid = pid
 
 	go m.sendLoop()
-	go m.encodeLoop()
 	go m.decodeLoop()
 
 	// wait for a listener error or a stop signal; either way stop the messenger
@@ -267,7 +292,7 @@ func (m *MesosMessenger) Stop() (err error) {
 			defer close(m.stop)
 		}
 
-		log.Info("stopping messenger..")
+		log.Infof("stopping messenger %v..", m.upid)
 
 		//TODO(jdef) don't hardcode the graceful flag here
 		if err2 := m.tr.Stop(true); err2 != nil && err2 != errTerminal {
@@ -283,53 +308,14 @@ func (m *MesosMessenger) UPID() upid.UPID {
 	return m.upid
 }
 
-func (m *MesosMessenger) encodeLoop() {
-	for {
-		select {
-		case <-m.stop:
-			return
-		case msg := <-m.encodingQueue:
-			e := func() error {
-				//TODO(jdef) implement timeout for context
-				ctx, cancel := context.WithCancel(context.TODO())
-				defer cancel()
-
-				b, err := proto.Marshal(msg.ProtoMessage)
-				if err != nil {
-					return err
-				}
-				msg.Bytes = b
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case m.sendingQueue <- msg:
-					return nil
-				}
-			}()
-			if e != nil {
-				m.reportError(fmt.Errorf("Failed to enqueue message %v: %v", msg, e))
-			}
-		}
+func (m *MesosMessenger) reportError(action string, msg *Message, err error) {
+	// log message transmission errors but don't shoot the messenger.
+	// this approach essentially drops all undelivered messages on the floor.
+	name := ""
+	if msg != nil {
+		name = msg.Name
 	}
-}
-
-func (m *MesosMessenger) reportError(err error) {
-	log.V(2).Info(err)
-	//TODO(jdef) implement timeout for context
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-
-	c := make(chan error, 1)
-	pid := m.upid
-	go func() { c <- m.Route(ctx, &pid, &mesos.FrameworkErrorMessage{Message: proto.String(err.Error())}) }()
-	select {
-	case <-ctx.Done():
-		<-c // wait for Route to return
-	case e := <-c:
-		if e != nil {
-			log.Errorf("failed to report error %v due to: %v", err, e)
-		}
-	}
+	log.Errorf("failed to %s message %q: %+v", action, name, err)
 }
 
 func (m *MesosMessenger) sendLoop() {
@@ -337,27 +323,25 @@ func (m *MesosMessenger) sendLoop() {
 		select {
 		case <-m.stop:
 			return
-		case msg := <-m.sendingQueue:
-			e := func() error {
-				//TODO(jdef) implement timeout for context
-				ctx, cancel := context.WithCancel(context.TODO())
-				defer cancel()
-
-				c := make(chan error, 1)
-				go func() { c <- m.tr.Send(ctx, msg) }()
-
-				select {
-				case <-ctx.Done():
-					// Transport layer must use the context to detect cancelled requests.
-					<-c // wait for Send to return
-					return ctx.Err()
-				case err := <-c:
-					return err
+		case f := <-m.sendingQueue:
+			f(responseFunc(func(ctx context.Context, msg *Message, err error) error {
+				if _, ok := err.(*networkError); ok {
+					// if transport reports a network error, then
+					// we're probably disconnected from the master?
+					pid := msg.UPID.String()
+					neterr := &mesos.InternalNetworkError{Pid: &pid}
+					sessionID, ok := sessionid.FromContext(ctx)
+					if ok {
+						neterr.Session = &sessionID
+					}
+					log.V(1).Infof("routing network error for pid %q session %q", pid, sessionID)
+					err2 := m.Route(ctx, &m.upid, neterr)
+					if err2 != nil {
+						log.Error(err2)
+					}
 				}
-			}()
-			if e != nil {
-				m.reportError(fmt.Errorf("Failed to send message %v: %v", msg.Name, e))
-			}
+				return err
+			}))
 		}
 	}
 }
@@ -379,15 +363,40 @@ func (m *MesosMessenger) decodeLoop() {
 				panic(fmt.Sprintf("unexpected transport error: %v", err))
 			}
 		}
+
 		log.V(2).Infof("Receiving message %v from %v\n", msg.Name, msg.UPID)
-		msg.ProtoMessage = reflect.New(m.installedMessages[msg.Name]).Interface().(proto.Message)
+		protoMessage, handler, found := m.messageBinding(msg.Name)
+		if !found {
+			log.Warningf("no message binding for message %q", msg.Name)
+			continue
+		}
+
+		msg.ProtoMessage = protoMessage
 		if err := proto.Unmarshal(msg.Bytes, msg.ProtoMessage); err != nil {
 			log.Errorf("Failed to unmarshal message %v: %v\n", msg, err)
 			continue
 		}
-		// TODO(yifan): Catch panic.
-		m.installedHandlers[msg.Name](msg.UPID, msg.ProtoMessage)
+
+		handler(msg.UPID, msg.ProtoMessage)
 	}
+}
+
+func (m *MesosMessenger) messageBinding(name string) (proto.Message, MessageHandler, bool) {
+	m.guardHandlers.RLock()
+	defer m.guardHandlers.RUnlock()
+
+	gotype, ok := m.installedMessages[name]
+	if !ok {
+		return nil, nil, false
+	}
+
+	handler, ok := m.installedHandlers[name]
+	if !ok {
+		return nil, nil, false
+	}
+
+	protoMessage := reflect.New(gotype).Interface().(proto.Message)
+	return protoMessage, handler, true
 }
 
 // getMessageName returns the name of the message in the mesos manner.

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -141,12 +141,12 @@ func UPIDBindingAddress(hostname string, bindingAddress net.IP) (string, error) 
 }
 
 // NewMesosMessenger creates a new mesos messenger.
-func NewHttp(upid upid.UPID) *MesosMessenger {
-	return NewHttpWithBindingAddress(upid, nil)
+func NewHttp(upid upid.UPID, opts ...httpOpt) *MesosMessenger {
+	return NewHttpWithBindingAddress(upid, nil, opts...)
 }
 
-func NewHttpWithBindingAddress(upid upid.UPID, address net.IP) *MesosMessenger {
-	return New(NewHTTPTransporter(upid, address))
+func NewHttpWithBindingAddress(upid upid.UPID, address net.IP, opts ...httpOpt) *MesosMessenger {
+	return New(NewHTTPTransporter(upid, address, opts...))
 }
 
 func New(t Transporter) *MesosMessenger {

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -327,7 +327,7 @@ func (m *MesosMessenger) sendLoop() {
 			f(responseFunc(func(ctx context.Context, msg *Message, err error) error {
 				if _, ok := err.(*networkError); ok {
 					// if transport reports a network error, then
-					// we're probably disconnected from the master?
+					// we're probably disconnected from the remote process?
 					pid := msg.UPID.String()
 					neterr := &mesos.InternalNetworkError{Pid: &pid}
 					sessionID, ok := sessionid.FromContext(ctx)

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -338,6 +338,9 @@ func (m *MesosMessenger) sendLoop() {
 					err2 := m.Route(ctx, &m.upid, neterr)
 					if err2 != nil {
 						log.Error(err2)
+					} else {
+						log.V(1).Infof("swallowing raw error because we're reporting a networkError: %v", err)
+						return nil
 					}
 				}
 				return err

--- a/messenger/sessionid/sessionid.go
+++ b/messenger/sessionid/sessionid.go
@@ -1,0 +1,18 @@
+package sessionid
+
+import (
+	"golang.org/x/net/context"
+)
+
+type key int
+
+const sessionIDKey = 0
+
+func NewContext(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, sessionIDKey, sessionID)
+}
+
+func FromContext(ctx context.Context) (string, bool) {
+	sessionID, ok := ctx.Value(sessionIDKey).(string)
+	return sessionID, ok
+}

--- a/messenger/transporter.go
+++ b/messenger/transporter.go
@@ -33,11 +33,6 @@ type Transporter interface {
 	//Will stop receiving when transport is stopped.
 	Recv() (*Message, error)
 
-	//Inject injects a message to the incoming queue. Must use context to
-	//determine cancelled requests. Injection is aborted if the transport
-	//is stopped.
-	Inject(ctx context.Context, msg *Message) error
-
 	//Install mount an handler based on incoming message name.
 	Install(messageName string)
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -382,7 +382,6 @@ func (driver *MesosSchedulerDriver) handleNetworkError(_ context.Context, from *
 
 		log.Info("master disconnected")
 		driver.connected = false
-		driver.connection = uuid.UUID{}
 		driver.authenticated = false
 	}
 }
@@ -408,7 +407,6 @@ func (driver *MesosSchedulerDriver) handleMasterChanged(_ context.Context, from 
 	master := msg.Master
 
 	driver.connected = false
-	driver.connection = uuid.UUID{}
 	driver.authenticated = false
 
 	if master != nil {

--- a/scheduler/scheduler_intgr_test.go
+++ b/scheduler/scheduler_intgr_test.go
@@ -212,7 +212,7 @@ var defaultMockServerConfigurator = mockServerConfigurator(func(frameworkId *mes
 		// this is what the mocked scheduler is expecting to receive
 		suite.driver.eventLock.Lock()
 		defer suite.driver.eventLock.Unlock()
-		suite.driver.frameworkRegistered(suite.driver.masterPid, &mesos.FrameworkRegisteredMessage{
+		suite.driver.frameworkRegistered(suite.driver.context(), suite.driver.masterPid, &mesos.FrameworkRegisteredMessage{
 			FrameworkId: frameworkId,
 			MasterInfo:  masterInfo,
 		})
@@ -228,7 +228,7 @@ var defaultMockServerConfigurator = mockServerConfigurator(func(frameworkId *mes
 		// this is what the mocked scheduler is expecting to receive
 		suite.driver.eventLock.Lock()
 		defer suite.driver.eventLock.Unlock()
-		suite.driver.frameworkReregistered(suite.driver.masterPid, &mesos.FrameworkReregisteredMessage{
+		suite.driver.frameworkReregistered(suite.driver.context(), suite.driver.masterPid, &mesos.FrameworkReregisteredMessage{
 			FrameworkId: frameworkId,
 			MasterInfo:  masterInfo,
 		})

--- a/scheduler/scheduler_unit_test.go
+++ b/scheduler/scheduler_unit_test.go
@@ -128,7 +128,7 @@ func TestSchedulerDriverNew_WithPid(t *testing.T) {
 	mUpid, err := upid.Parse(masterAddr)
 	assert.NoError(t, err)
 	driver := newTestSchedulerDriver(t, driverConfig(NewMockScheduler(), &mesos.FrameworkInfo{}, masterAddr, nil))
-	driver.handleMasterChanged(driver.self, &mesos.InternalMasterChangeDetected{Master: &mesos.MasterInfo{Pid: proto.String(mUpid.String())}})
+	driver.handleMasterChanged(context.TODO(), driver.self, &mesos.InternalMasterChangeDetected{Master: &mesos.MasterInfo{Pid: proto.String(mUpid.String())}})
 	assert.True(t, driver.masterPid.Equal(mUpid), fmt.Sprintf("expected upid %+v instead of %+v", mUpid, driver.masterPid))
 	assert.NoError(t, err)
 }
@@ -394,7 +394,7 @@ func (suite *SchedulerTestSuite) TestSchedulerDriverErrorBeforeConnected() {
 	func() {
 		driver.eventLock.Lock()
 		defer driver.eventLock.Unlock()
-		driver.error(msg) // this is the callback that's eventually invoked when receiving an error from the master
+		driver.error(context.TODO(), msg) // this is the callback that's eventually invoked when receiving an error from the master
 	}()
 
 	<-errorTracker.called


### PR DESCRIPTION
fixes here include:
* messenger does not abort upon transport errors
* scheduler and executor observe network errors as indicators of disconnection
* additional debugging flag for example scheduler
* removed separate go-routine for message encoding
* context.Context from sender (sched/exec driver) is preserved down to the transport level
* increased default http read/write timeouts
* functional config of TLS for client/server; TLS is very **untested** at this point
* initial support for executor recovery
* resolve deadlocks in certain disconnection scenarios