### PR TITLE
Specify binding ports for authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
   - 1.5.1
   - tip
 before_install:
-  - go get golang.org/x/tools/cmd/vet
    #these two lines help users who fork mesos-go. It's a noop when running from the mesos organization
   - RepoName=`basename $PWD`; SrcDir=`dirname $PWD`; DestDir="`dirname $SrcDir`/mesos"
   - if [[ "$SrcDir" != "$DestDir" ]]; then mv "$SrcDir" "$DestDir"; cd ../../mesos/$RepoName; export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$RepoName; fi

--- a/auth/sasl/authenticatee.go
+++ b/auth/sasl/authenticatee.go
@@ -76,11 +76,14 @@ func init() {
 			if parent == nil {
 				log.Fatal("expected to have a parent UPID in context")
 			}
+
 			process := process.New("sasl_authenticatee")
 			tpid := upid.UPID{
 				ID:   process.Label(),
 				Host: parent.Host,
+				Port: BindingPortFrom(ctx),
 			}
+
 			return messenger.NewHttpWithBindingAddress(tpid, BindingAddressFrom(ctx))
 		})
 	}

--- a/auth/sasl/context.go
+++ b/auth/sasl/context.go
@@ -2,6 +2,7 @@ package sasl
 
 import (
 	"net"
+	"strconv"
 
 	"golang.org/x/net/context"
 )
@@ -15,6 +16,7 @@ type _key int
 const (
 	statusKey         _key = iota
 	bindingAddressKey      // bind address for login-related network ops
+	bindingPortKey         // port to bind auth listener if a specific port is needed
 )
 
 func withStatus(ctx context.Context, s statusType) context.Context {
@@ -40,4 +42,15 @@ func BindingAddressFrom(ctx context.Context) net.IP {
 	} else {
 		return nil
 	}
+}
+
+func WithBindingPort(ctx context.Context, port uint16) context.Context {
+	return context.WithValue(ctx, bindingPortKey, port)
+}
+
+func BindingPortFrom(ctx context.Context) string {
+	if port, ok := ctx.Value(bindingPortKey).(uint16); ok {
+		return strconv.Itoa(int(port))
+	}
+	return "0"
 }


### PR DESCRIPTION
Provide mechanism to specify binding port for authentication, addressing #229, using the context and a new `sasl.WithBindingPort(ctx context.Context, port uint16) ctx.Context` helper function and related code.