### PR TITLE
Removed hardcoded type assertion in decoder.go

### DIFF
--- a/encoding/framing/decoder.go
+++ b/encoding/framing/decoder.go
@@ -52,7 +52,7 @@ func (d *Decoder) Decode(m interface{}) error {
 		}
 
 		if eof {
-			return d.uf(d.buf[:readlen], m.(proto.Message))
+			return d.uf(d.buf[:readlen], m)
 		}
 
 		if len(buf) == nr {


### PR DESCRIPTION
framing.Decoder.Decode currently has a hardcoded type assertion for protocol buffers. This change will allow json unmarshalers as well.