### PR TITLE
Prevent panic on nil driver

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -515,6 +515,9 @@ func (driver *MesosExecutorDriver) frameworkError(_ context.Context, from *upid.
 
 // Start starts the executor driver
 func (driver *MesosExecutorDriver) Start() (mesosproto.Status, error) {
+	if driver == nil {
+		return mesosproto.Status_DRIVER_ABORTED, fmt.Errorf("Can't Start() driver because driver is nil!")
+	}
 	driver.lock.Lock()
 	defer driver.lock.Unlock()
 	return driver.start()


### PR DESCRIPTION
This shouldn't really happen in a real scenario, but the code probably shouldn't crash in this circumstance. If the driver is nil and `Start()` is still called, it will panic because no `nil` check was being done against the driver. This behavior happens e.g. in the example executor when not run from Mesos.

Steps to reproduce:

1. Compile example executor
2. Execute it
3. Panic