### PR TITLE
Add support for suppressing offers

### DIFF
--- a/scheduler/calls/calls.go
+++ b/scheduler/calls/calls.go
@@ -145,6 +145,14 @@ func Revive() *scheduler.Call {
 	}
 }
 
+// Suppress returns a suppress call.
+// Callers are expected to fill in the FrameworkID.
+func Suppress() *scheduler.Call {
+	return &scheduler.Call{
+		Type: scheduler.Call_SUPPRESS.Enum(),
+	}
+}
+
 // Decline returns a decline call with the given parameters.
 // Callers are expected to fill in the FrameworkID and Filters.
 func Decline(offerIDs ...mesos.OfferID) *scheduler.Call {


### PR DESCRIPTION
Allows frameworks to suppress offers (vital for not messing with DRF when many different frameworks are used).