### PR TITLE
Modified Makefile to test only directories with tests available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ PROTO_PATH := ${PROTO_PATH}:./vendor/github.com/gogo/protobuf/protobuf
 PROTO_PATH := ${PROTO_PATH}:./vendor/github.com/gogo/protobuf/gogoproto
 
 PACKAGES ?= $(shell go list ./...|grep -v vendor)
+TEST_DIRS ?= $(sort $(dir $(shell find . -name '*_test.go' | grep -v vendor)))
 BINARIES ?= $(shell go list -f "{{.Name}} {{.ImportPath}}" ./cmd/...|grep -v -e vendor|grep -e ^main|cut -f2 -d' ')
-TEST_FLAGS ?= -v -race
+TEST_FLAGS ?= -race
 
 .PHONY: all
 all: test
@@ -15,7 +16,11 @@ install:
 
 .PHONY: test
 test:
-	go $@ $(TEST_FLAGS) $(PACKAGES)
+	go $@ $(TEST_FLAGS) $(TEST_DIRS)
+
+.PHONY: test-verbose
+test-verbose: TEST_FLAGS += -v
+test-verbose: test
 
 .PHONY: vet
 vet:

--- a/encoding/framing/decoder.go
+++ b/encoding/framing/decoder.go
@@ -2,8 +2,6 @@ package framing
 
 import (
 	"fmt"
-
-	"github.com/gogo/protobuf/proto"
 )
 
 type (


### PR DESCRIPTION
At the moment, tests are run on *every* subpackage within mesos-go,
which generates a lot of failures since tests aren't available in many
packages at the moment. This diff changes the test target to only run
tests on subpackages with tests available so we get more signal from the
tests.

Also removed an unused import in decoder.go