### PR TITLE
executor backoff typo fix (3/4 instead of 4/3)

### DIFF
--- a/api/v1/cmd/example-executor/main.go
+++ b/api/v1/cmd/example-executor/main.go
@@ -38,7 +38,7 @@ func main() {
 
 func maybeReconnect(cfg config.Config) <-chan struct{} {
 	if cfg.Checkpoint {
-		return backoff.Notifier(1*time.Second, cfg.SubscriptionBackoffMax*4/3, nil)
+		return backoff.Notifier(1*time.Second, cfg.SubscriptionBackoffMax*3/4, nil)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #295