### PR TITLE
encoding: refactor Decoder and Encoder as single-function interfaces w/ functional adapters

### DIFF
--- a/api/v1/cmd/example-executor/main.go
+++ b/api/v1/cmd/example-executor/main.go
@@ -81,7 +81,7 @@ func run(cfg config.Config) {
 			}
 			if err == nil {
 				// we're officially connected, start decoding events
-				err = eventLoop(state, resp.Decoder(), handler)
+				err = eventLoop(state, resp, handler)
 				disconnected = time.Now()
 			}
 			if err != nil && err != io.EOF {
@@ -144,7 +144,7 @@ func eventLoop(state *internalState, decoder encoding.Decoder, h events.Handler)
 		sendFailedTasks(state)
 
 		var e executor.Event
-		if err = decoder.Invoke(&e); err == nil {
+		if err = decoder.Decode(&e); err == nil {
 			err = h.HandleEvent(&e)
 		}
 	}

--- a/api/v1/lib/client.go
+++ b/api/v1/lib/client.go
@@ -13,7 +13,7 @@ type Client interface {
 	Do(encoding.Marshaler) (Response, error)
 }
 
-// ClientFunc is a functional variant (and implementation) of the Client interface
+// ClientFunc is a functional adapter of the Client interface
 type ClientFunc func(encoding.Marshaler) (Response, error)
 
 // Do implements Client
@@ -23,19 +23,35 @@ func (cf ClientFunc) Do(m encoding.Marshaler) (Response, error) { return cf(m) }
 // Close when they're finished processing the response otherwise there may be connection leaks.
 type Response interface {
 	io.Closer
-	Decoder() encoding.Decoder
+	encoding.Decoder
 }
 
-// ResponseWrapper delegates to optional handler funcs for invocations of Response methods.
+// ResponseDecorator optionally modifies the behavior of a Response
+type ResponseDecorator interface {
+	Decorate(Response) Response
+}
+
+// ResponseDecoratorFunc is the functional adapter for ResponseDecorator
+type ResponseDecoratorFunc func(Response) Response
+
+func (f ResponseDecoratorFunc) Decorate(r Response) Response { return f(r) }
+
+// CloseFunc is the functional adapter for io.Closer
+type CloseFunc func() error
+
+// Close implements io.Closer
+func (f CloseFunc) Close() error { return f() }
+
+// ResponseWrapper delegates to optional overrides for invocations of Response methods.
 type ResponseWrapper struct {
-	Response    Response
-	CloseFunc   func() error
-	DecoderFunc func() encoding.Decoder
+	Response Response
+	Closer   io.Closer
+	Decoder  encoding.Decoder
 }
 
 func (wrapper *ResponseWrapper) Close() error {
-	if wrapper.CloseFunc != nil {
-		return wrapper.CloseFunc()
+	if wrapper.Closer != nil {
+		return wrapper.Closer.Close()
 	}
 	if wrapper.Response != nil {
 		return wrapper.Response.Close()
@@ -43,9 +59,11 @@ func (wrapper *ResponseWrapper) Close() error {
 	return nil
 }
 
-func (wrapper *ResponseWrapper) Decoder() encoding.Decoder {
-	if wrapper.DecoderFunc != nil {
-		return wrapper.DecoderFunc()
+func (wrapper *ResponseWrapper) Decode(u encoding.Unmarshaler) error {
+	if wrapper.Decoder != nil {
+		return wrapper.Decoder.Decode(u)
 	}
-	return wrapper.Response.Decoder()
+	return wrapper.Response.Decode(u)
 }
+
+var _ = Response(&ResponseWrapper{})

--- a/api/v1/lib/extras/scheduler/controller/controller.go
+++ b/api/v1/lib/extras/scheduler/controller/controller.go
@@ -91,7 +91,7 @@ func processSubscription(config Config, resp mesos.Response, err error) error {
 		defer resp.Close()
 	}
 	if err == nil {
-		err = eventLoop(config, resp.Decoder())
+		err = eventLoop(config, resp)
 	}
 	return err
 }
@@ -105,7 +105,7 @@ func eventLoop(config Config, eventDecoder encoding.Decoder) (err error) {
 	}
 	for err == nil && !config.Context.Done() {
 		var e scheduler.Event
-		if err = eventDecoder.Invoke(&e); err == nil {
+		if err = eventDecoder.Decode(&e); err == nil {
 			err = h.HandleEvent(&e)
 		}
 	}


### PR DESCRIPTION
breaking API changes:
* functional variants are now `encoding.DecoderFunc` and `encoding.EncoderFunc`
* `Response` now composes `encoding.Decoder` instead of exposing a `Decoder()` func