### PR TITLE
apierrors: make response message more descriptive

### DIFF
--- a/api/v1/lib/httpcli/apierrors/apierrors.go
+++ b/api/v1/lib/httpcli/apierrors/apierrors.go
@@ -95,5 +95,5 @@ func FromResponse(res *http.Response) error {
 
 // Error implements error interface
 func (err *Error) Error() string {
-	return err.Message
+	return err.Message + ": " + err.Details
 }

--- a/api/v1/lib/httpcli/apierrors/apierrors.go
+++ b/api/v1/lib/httpcli/apierrors/apierrors.go
@@ -95,5 +95,8 @@ func FromResponse(res *http.Response) error {
 
 // Error implements error interface
 func (err *Error) Error() string {
-	return err.Message + ": " + err.Details
+	if err.Details != "" {
+		return err.Message + ": " + err.Details
+	}
+	return err.Message 
 }

--- a/api/v1/lib/httpcli/apierrors/apierrroes_test.go
+++ b/api/v1/lib/httpcli/apierrors/apierrroes_test.go
@@ -1,0 +1,45 @@
+package apierrors
+
+import (
+	"testing"
+	"net/http"
+	"io/ioutil"
+	"bytes"
+	"reflect"
+)
+
+func TestFromResponse(t *testing.T) {
+	for _, tt := range([]struct {
+		r *http.Response
+		e error
+	} {
+		{ nil, nil },
+		{
+			&http.Response{ StatusCode: 200 },
+			nil,
+		},
+		{
+			&http.Response{ StatusCode: 400, Body: ioutil.NopCloser(bytes.NewBufferString("missing framework id")) },
+			&Error{ 400, ErrorTable[CodeMalformedRequest], "missing framework id"},
+		},
+	}) {
+		rr := FromResponse(tt.r)
+		if !reflect.DeepEqual(tt.e, rr) {
+			t.Errorf("Expected: %v, got: %v", tt.e, rr)
+		}
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	for _, tt := range([]struct {
+		e Error
+		m string
+	} {
+		{ Error{400, "malformed request", "missing framework id"}, "malformed request: missing framework id" },
+		{ Error{400, "malformed request", ""}, "malformed request" },
+	}) {
+		if tt.e.Error() != tt.m {
+			t.Errorf("Expected: %s, got: %s", tt.m, tt.e.Error())
+		}
+	}
+}


### PR DESCRIPTION
Something like *malformed request: Failed to validate scheduler::Call: Expecting 'framework_id' to be present* is more helpful than just "malformed request" 