### PR TITLE
Upgrade golang versioin to 1.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ docker:
 	mkdir -p _output
 	test -n "$(UID)" || (echo 'ERROR: $$UID is undefined'; exit 1)
 	test -n "$(GID)" || (echo 'ERROR: $$GID is undefined'; exit 1)
-	docker run --rm -v "$$PWD":/src -w /go/src/$(GOPKG_DIRNAME) golang:1.6.1-alpine sh -c $(BUILD_STEP)' && '$(COPY_STEP)
+	docker run --rm -v "$$PWD":/src -w /go/src/$(GOPKG_DIRNAME) golang:1.8.1-alpine sh -c $(BUILD_STEP)' && '$(COPY_STEP)
 	make -C api/${MESOS_API_VERSION}/docker
 
 .PHONY: coveralls


### PR DESCRIPTION
With golang1.6.1, when 'make docker', we will encounter the following issue,
```
api/v1/cmd/example-executor/main.go:4:2: cannot find package "context" in any of:
        /go/src/github.com/mesos/mesos-go/api/v1/cmd/vendor/context (vendor tree)
        /go/src/github.com/mesos/mesos-go/api/v1/vendor/context
        /usr/local/go/src/context (from $GOROOT)
        /go/src/context (from $GOPATH)
Makefile:108: recipe for target 'docker' failed
```
This is because golang has no package "context", so upgrade golang to 1.8.1 .

Signed-off-by: Shukui Yang <yangshukui@huawei.com>