### PR TITLE
Prohibit http.Client from following internal redirects

### DIFF
--- a/api/v1/lib/httpcli/http.go
+++ b/api/v1/lib/httpcli/http.go
@@ -22,6 +22,8 @@ import (
 	"github.com/mesos/mesos-go/api/v1/lib/recordio"
 )
 
+func noRedirect(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+
 // ProtocolError is returned when we receive a response from Mesos that is outside of the HTTP API specification.
 // Receipt of the following will yield protocol errors:
 //   - any unexpected non-error HTTP response codes (e.g. 199)
@@ -517,7 +519,10 @@ func With(opt ...ConfigOpt) DoFunc {
 		config = &Config{
 			dialer:    dialer,
 			transport: transport,
-			client:    &http.Client{Transport: transport},
+			client: &http.Client{
+				Transport:     transport,
+				CheckRedirect: noRedirect, // so we can actually see the 307 redirects
+			},
 		}
 	)
 	for _, o := range opt {


### PR DESCRIPTION
By prohibiting internal redirects inside of http.Client, we can let the framework code actually witness the 307 non-master redirects and update endpoint logic accordingly.