### PR TITLE
feature flag opt-in for re-subscribe

### DIFF
--- a/api/v1/lib/httpcli/httpsched/httpsched.go
+++ b/api/v1/lib/httpcli/httpsched/httpsched.go
@@ -37,7 +37,8 @@ type (
 
 	client struct {
 		*httpcli.Client
-		redirect RedirectSettings
+		redirect       RedirectSettings
+		allowReconnect bool // feature flag
 	}
 
 	// Caller is the public interface a framework scheduler's should consume
@@ -93,6 +94,14 @@ func MaxRedirects(mr int) Option {
 		old := c.redirect.MaxAttempts
 		c.redirect.MaxAttempts = mr
 		return MaxRedirects(old)
+	}
+}
+
+func AllowReconnection(v bool) Option {
+	return func(c *client) Option {
+		old := c.allowReconnect
+		c.allowReconnect = v
+		return AllowReconnection(old)
 	}
 }
 


### PR DESCRIPTION
I noticed that the v1 scheduler workflow isn't re-subscribe friendly, which makes implementing proper heartbeat handling in a framework tricky.

This PR adds the bare minimum hooks necessary to test out re-SUBSCRIBE on an opt-in basis. It "should" be safe to do without the feature-flag, but the comments by jdef in the source imply otherwise.

Doing this without the opt-in does have repercussions on anyone who is currently invoking a SUBSCRIBE call. To avoid issues with receiving one last `scheduler.Event_ERROR` message on the old subscription socket, you have to do some additional state tracking in framework code to correctly handle it.  As I'm not using the helpers in the `extras` directory, I'm not sure the right way to handle the workflow there so I didn't make any changes to try and use the re-subscribe changes there.