### PR TITLE
support multiple master candidates

### DIFF
--- a/api/v1/lib/httpcli/http.go
+++ b/api/v1/lib/httpcli/http.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -74,7 +73,6 @@ type ResponseHandler func(*http.Response, client.ResponseClass, error) (mesos.Re
 // A Client is a Mesos HTTP APIs client.
 type Client struct {
 	url              string
-	candidates       string
 	do               DoFunc
 	header           http.Header
 	codec            encoding.Codec
@@ -128,14 +126,7 @@ func cloneHeaders(hs http.Header) http.Header {
 
 // Endpoint returns the current Mesos API endpoint URL that the caller is set to invoke
 func (c *Client) Endpoint() string {
-	if c.url == "" && c.candidates != "" {
-		c.url = strings.Split(c.candidates, ",")[0]
-	}
 	return c.url
-}
-
-func (c *Client) Candidates() string {
-	return c.candidates
 }
 
 // RequestOpt defines a functional option for an http.Request.
@@ -214,7 +205,7 @@ func (c *Client) buildRequest(cr client.Request, rc client.ResponseClass, opt ..
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", c.Endpoint(), &body)
+	req, err := http.NewRequest("POST", c.url, &body)
 	if err != nil {
 		return nil, err
 	}
@@ -427,15 +418,6 @@ func Endpoint(rawurl string) Opt {
 		old := c.url
 		c.url = rawurl
 		return Endpoint(old)
-	}
-}
-
-// URL returns an Opt that sets a Client's Candidates.
-func Candidates(rawurls string) Opt {
-	return func(c *Client) Opt {
-		old := c.candidates
-		c.candidates = rawurls
-		return Candidates(old)
 	}
 }
 

--- a/api/v1/lib/httpcli/http.go
+++ b/api/v1/lib/httpcli/http.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -73,6 +74,7 @@ type ResponseHandler func(*http.Response, client.ResponseClass, error) (mesos.Re
 // A Client is a Mesos HTTP APIs client.
 type Client struct {
 	url              string
+	candidates       string
 	do               DoFunc
 	header           http.Header
 	codec            encoding.Codec
@@ -126,7 +128,14 @@ func cloneHeaders(hs http.Header) http.Header {
 
 // Endpoint returns the current Mesos API endpoint URL that the caller is set to invoke
 func (c *Client) Endpoint() string {
+	if c.url == "" && c.candidates != "" {
+		c.url = strings.Split(c.candidates, ",")[0]
+	}
 	return c.url
+}
+
+func (c *Client) Candidates() string {
+	return c.candidates
 }
 
 // RequestOpt defines a functional option for an http.Request.
@@ -205,7 +214,7 @@ func (c *Client) buildRequest(cr client.Request, rc client.ResponseClass, opt ..
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", c.url, &body)
+	req, err := http.NewRequest("POST", c.Endpoint(), &body)
 	if err != nil {
 		return nil, err
 	}
@@ -418,6 +427,15 @@ func Endpoint(rawurl string) Opt {
 		old := c.url
 		c.url = rawurl
 		return Endpoint(old)
+	}
+}
+
+// URL returns an Opt that sets a Client's Candidates.
+func Candidates(rawurls string) Opt {
+	return func(c *Client) Opt {
+		old := c.candidates
+		c.candidates = rawurls
+		return Candidates(old)
 	}
 }
 

--- a/api/v1/lib/httpcli/httpsched/httpsched.go
+++ b/api/v1/lib/httpcli/httpsched/httpsched.go
@@ -39,7 +39,7 @@ type (
 		*httpcli.Client
 		redirect          RedirectSettings
 		allowReconnect    bool // feature flag
-		listener       func(Notification)
+		listener          func(Notification)
 		candidateSelector CandidateSelector
 	}
 

--- a/api/v1/lib/httpcli/httpsched/httpsched.go
+++ b/api/v1/lib/httpcli/httpsched/httpsched.go
@@ -193,10 +193,11 @@ func (cli *client) httpDo(ctx context.Context, m encoding.Marshaler, opt ...http
 			var candidate string
 			if !ok {
 				if cli.candidateSelector == nil {
-					log.Printf("not found candidate selector, return directly")
-					return
+					log.Printf("not found candidate selector, using url when initilize framework")
+					candidate = cli.Endpoint()
+				} else {
+					candidate = cli.candidateSelector()
 				}
-				candidate = cli.candidateSelector()
 				if candidate == "" {
 					log.Printf("not found candidate url, return directly")
 					return


### PR DESCRIPTION
In this pr, if the mesos framework specify a candidate selector(could be dynamic func), the framework will gain the ability to failover across multiple mesos masters. otherwise, it will only rely on the url as an initial configuration.