### PR TITLE
Add go get to make install to fix a missing dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ all: test
 .PHONY: install
 install: INSTALL_FLAGS +=
 install:
+	go get ./...
 	go install $(INSTALL_FLAGS) $(BINARIES)
 
 .PHONY: test


### PR DESCRIPTION
Without the `go get ./...` step, a newly configured environment does not
automatically import the ffjson and uuid libraries, causing `make install` to
fail due to missing dependencies.