### PR TITLE
httpcli: Content-Length as obj type indicator

### DIFF
--- a/api/v1/lib/httpcli/http_test.go
+++ b/api/v1/lib/httpcli/http_test.go
@@ -50,15 +50,17 @@ func TestPrepareForResponse(t *testing.T) {
 
 func TestNewSourceFactory(t *testing.T) {
 	for ti, tc := range []struct {
-		rc         client.ResponseClass
-		wantsNil   bool
-		wantsPanic bool
+		rc          client.ResponseClass
+		knownLength bool
+		wantsNil    bool
+		wantsPanic  bool
 	}{
-		{client.ResponseClass(-1), false, true},
-		{client.ResponseClassNoData, true, false},
-		{client.ResponseClassAuto, false, false},
-		{client.ResponseClassSingleton, false, false},
-		{client.ResponseClassStreaming, false, false},
+		{client.ResponseClass(-1), false, false, true},
+		{client.ResponseClassNoData, false, true, false},
+		{client.ResponseClassAuto, false, false, false},
+		{client.ResponseClassAuto, true, false, false},
+		{client.ResponseClassSingleton, false, false, false},
+		{client.ResponseClassStreaming, false, false, false},
 	} {
 		f := func() encoding.SourceFactoryFunc {
 			defer func() {
@@ -66,7 +68,7 @@ func TestNewSourceFactory(t *testing.T) {
 					panic(x)
 				}
 			}()
-			return newSourceFactory(tc.rc)
+			return newSourceFactory(tc.rc, tc.knownLength)
 		}()
 		if tc.wantsPanic {
 			continue


### PR DESCRIPTION
For higher level clients using ResponseClassAuto (e.g. scheduler
callers) infer the response object type based on the Content-Length
header in the HTTP response. Streaming responses using recordio will not
have sent a Content-Length header, whereas "singleton" JSON object
responses will have one.