### PR TITLE
Bump resource math

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ git:
 env:
   - PROTOBUF_VERSION=3.3.0
 go:
-  # update validate-protobufs Makefile target once golang 1.10.x is no longer tested here
-  - 1.8.x
+  # update validate-protobufs Makefile target once golang 1.11.x is no longer tested here
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 before_install:
    #these two lines help users who fork mesos-go. It's a noop when running from the mesos organization
   - RepoName=`basename $PWD`; SrcDir=`dirname $PWD`; DestDir="`dirname $SrcDir`/mesos"
@@ -19,7 +19,7 @@ before_install:
   - make sync
   - api/v1/vendor/github.com/gogo/protobuf/install-protobuf.sh
   # re-generate protobuf and json code, check that there are no differences w/ respect to what's been checked in
-  # ONLY for golang1.10.x; generated protobufs are not guaranteed to be consistent across golang versions
+  # ONLY for golang1.11.x; generated protobufs are not guaranteed to be consistent across golang versions
   - make validate-protobufs
 install:
   - make test install

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+2019-xx-xx: v0.0.9
+  1.7.x protobuf support
+  resources: initial support for reservation-refinement in resource algebra, may be enabled
+  programmatically or at link-time via:
+  `-ldflags "-X github.com/mesos/mesos-go/api/v1/lib.CapabilityReservationRefinement=1"`.
+  controller: eventLoop returns context error if done
+  controller: WithContextPerSubscription
+  controller: option WithInitiallySuppressedRoles
+  backoff: avoid Timer.Reset() problems; honor minWait promise
+  httpsched: EndpointCandidates()
+
 2018-07-26: v0.0.8
   1.6.x protobuf support
 

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ docker:
 	mkdir -p _output
 	test -n "$(UID)" || (echo 'ERROR: $$UID is undefined'; exit 1)
 	test -n "$(GID)" || (echo 'ERROR: $$GID is undefined'; exit 1)
-	docker run --rm -v "$$PWD":/src -w /go/src/$(GOPKG_DIRNAME) golang:1.10.1-alpine sh -c $(BUILD_STEP)' && '$(COPY_STEP)
+	docker run --rm -v "$$PWD":/src -w /go/src/$(GOPKG_DIRNAME) golang:1.11.5-alpine sh -c $(BUILD_STEP)' && '$(COPY_STEP)
 	make -C api/${MESOS_API_VERSION}/docker
 
 .PHONY: coveralls
@@ -171,7 +171,7 @@ coveralls:
 
 # re-generate protobuf and json code, check that there are no differences w/ respect to what's been checked in
 .PHONY: validate-protobufs
-ifeq ($(GO_VERSION),go1.10)
+ifeq ($(GO_VERSION),go1.11)
 validate-protobufs: SHELL := /bin/bash
 validate-protobufs:
 	(cd api/v1; govendor install +vendor,program) && $(MAKE) -s protobufs ffjson && [[ `{ git status --porcelain || echo "failed"; } | tee /tmp/status | wc -l` = "0" ]] || { cat /tmp/status; git diff; false; }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The Mesos v0 API version of the bindings, located in `api/v0`, are more mature b
 ### Pre-Requisites
 - Go 1.7 or higher; https://golang.org/dl/
     - A standard and working Go workspace setup (multiple golang versions are tested via CI)
-- Apache Mesos 1.0 or newer; http://mesos.apache.org/downloads/
+- Apache Mesos 1.x; http://mesos.apache.org/downloads/
 - protoc compiler; https://github.com/google/protobuf/releases
     - v3.3.x is tested by CI and should be used for code generation
 - `govendor`; https://github.com/kardianos/govendor

--- a/api/v1/lib/resources.go
+++ b/api/v1/lib/resources.go
@@ -288,8 +288,10 @@ func (resources Resources) Format(options ...func(*ResourcesFormatOptions)) stri
 				switch s.GetType() {
 				case Resource_DiskInfo_Source_BLOCK:
 					buf.WriteString("BLOCK")
-					if id, profile := s.GetID(), s.GetProfile(); id != "" || profile != "" {
+					if id, profile, vendor := s.GetID(), s.GetProfile(), s.GetVendor(); id != "" || profile != "" || vendor != "" {
 						buf.WriteByte('(')
+						buf.WriteString(vendor)
+						buf.WriteByte(',')
 						buf.WriteString(id)
 						buf.WriteByte(',')
 						buf.WriteString(profile)
@@ -297,8 +299,10 @@ func (resources Resources) Format(options ...func(*ResourcesFormatOptions)) stri
 					}
 				case Resource_DiskInfo_Source_RAW:
 					buf.WriteString("RAW")
-					if id, profile := s.GetID(), s.GetProfile(); id != "" || profile != "" {
+					if id, profile, vendor := s.GetID(), s.GetProfile(), s.GetVendor(); id != "" || profile != "" || vendor != "" {
 						buf.WriteByte('(')
+						buf.WriteString(vendor)
+						buf.WriteByte(',')
 						buf.WriteString(id)
 						buf.WriteByte(',')
 						buf.WriteString(profile)
@@ -306,8 +310,10 @@ func (resources Resources) Format(options ...func(*ResourcesFormatOptions)) stri
 					}
 				case Resource_DiskInfo_Source_PATH:
 					buf.WriteString("PATH")
-					if id, profile := s.GetID(), s.GetProfile(); id != "" || profile != "" {
+					if id, profile, vendor := s.GetID(), s.GetProfile(), s.GetVendor(); id != "" || profile != "" || vendor != "" {
 						buf.WriteByte('(')
+						buf.WriteString(vendor)
+						buf.WriteByte(',')
 						buf.WriteString(id)
 						buf.WriteByte(',')
 						buf.WriteString(profile)
@@ -318,8 +324,10 @@ func (resources Resources) Format(options ...func(*ResourcesFormatOptions)) stri
 					}
 				case Resource_DiskInfo_Source_MOUNT:
 					buf.WriteString("MOUNT")
-					if id, profile := s.GetID(), s.GetProfile(); id != "" || profile != "" {
+					if id, profile, vendor := s.GetID(), s.GetProfile(), s.GetVendor(); id != "" || profile != "" || vendor != "" {
 						buf.WriteByte('(')
+						buf.WriteString(vendor)
+						buf.WriteByte(',')
 						buf.WriteString(id)
 						buf.WriteByte(',')
 						buf.WriteString(profile)
@@ -659,6 +667,9 @@ func (left *Resource_DiskInfo) Equivalent(right *Resource_DiskInfo) bool {
 			return false
 		}
 		if aa, bb := a.GetProfile(), b.GetProfile(); aa != bb {
+			return false
+		}
+		if aa, bb := a.GetVendor(), b.GetVendor(); aa != bb {
 			return false
 		}
 		if aa, bb := a.GetMetadata(), b.GetMetadata(); (aa == nil) != (bb == nil) {

--- a/api/v1/lib/resources_test.go
+++ b/api/v1/lib/resources_test.go
@@ -762,10 +762,10 @@ func TestReservedResources_Validation(t *testing.T) {
 		if tc.wantsErr != (err != nil) {
 			if tc.wantsErr {
 				// expected failure
-				t.Errorf("test case %d failed: expected validation failure for %q", ti, tc.r)
+				t.Errorf("test case %d failed: expected validation failure for %v", ti, tc.r)
 			} else {
 				// unexpected failure
-				t.Errorf("test case %d failed: unexpected validation error for %q: %+v", ti, tc.r, err)
+				t.Errorf("test case %d failed: unexpected validation error for %v: %+v", ti, tc.r, err)
 			}
 		}
 	}
@@ -828,7 +828,7 @@ func TestReservedResources_Equivalence(t *testing.T) {
 				continue
 			}
 			if left.Equivalent(unique[j]) {
-				t.Errorf("unexpected equivalence for resources: %q and %q", left, unique[j])
+				t.Errorf("unexpected equivalence for resources: %v and %v", left, unique[j])
 			}
 		}
 	}

--- a/api/v1/lib/resourcetest/resourcetest.go
+++ b/api/v1/lib/resourcetest/resourcetest.go
@@ -184,6 +184,7 @@ func Create(r mesos.Resources) *mesos.Offer_Operation {
 }
 
 func Expect(t *testing.T, cond bool, msgformat string, args ...interface{}) bool {
+	t.Helper()
 	if !cond {
 		t.Errorf(msgformat, args...)
 	}

--- a/api/v1/lib/scheduler/operations/operations.go
+++ b/api/v1/lib/scheduler/operations/operations.go
@@ -233,7 +233,7 @@ func opDestroy(operation *mesos.Offer_Operation, resources mesos.Resources, conv
 
 		if rez.Contains(result, volumes[i]) {
 			return nil, fmt.Errorf(
-				"persistent volume %q cannot be removed due to additional shared copies", volumes[i])
+				"persistent volume %v cannot be removed due to additional shared copies", volumes[i])
 		}
 
 		// Strip the disk info so that we can subtract it from the
@@ -267,7 +267,7 @@ func opGrowVolume(operation *mesos.Offer_Operation, resources mesos.Resources, c
 	}
 
 	if !rez.ContainsAll(result, consumed) {
-		return nil, fmt.Errorf("%q does not contain %q", result, consumed)
+		return nil, fmt.Errorf("%v does not contain %v", result, consumed)
 	}
 
 	result.Subtract(consumed...)
@@ -285,7 +285,7 @@ func opShrinkVolume(operation *mesos.Offer_Operation, resources mesos.Resources,
 	consumed := operation.GetShrinkVolume().GetVolume()
 
 	if !rez.Contains(result, consumed) {
-		return nil, fmt.Errorf("%q does not contain %q", result, consumed)
+		return nil, fmt.Errorf("%v does not contain %v", result, consumed)
 	}
 
 	result.Subtract1(consumed)
@@ -303,7 +303,7 @@ func opCreateDisk(operation *mesos.Offer_Operation, resources mesos.Resources, c
 	consumed := operation.GetCreateDisk().GetSource()
 
 	if !rez.Contains(result, consumed) {
-		return nil, fmt.Errorf("%q does not contain %q", result, consumed)
+		return nil, fmt.Errorf("%v does not contain %v", result, consumed)
 	}
 
 	result.Subtract1(consumed)
@@ -319,7 +319,7 @@ func opDestroyDisk(operation *mesos.Offer_Operation, resources mesos.Resources, 
 	consumed := operation.GetDestroyDisk().GetSource()
 
 	if !rez.Contains(result, consumed) {
-		return nil, fmt.Errorf("%q does not contain %q", result, consumed)
+		return nil, fmt.Errorf("%v does not contain %v", result, consumed)
 	}
 
 	result.Subtract1(consumed)


### PR DESCRIPTION
Notable changes:

- resources: initial support for reservation-refinement in resource algebra, may be enabled programmatically or at link-time via: `-ldflags "-X github.com/mesos/mesos-go/api/v1/lib.CapabilityReservationRefinement=1"`.
- better support for `DiskInfo.Source.vendor` field