### PR TITLE
Add heartbeat helper method

### DIFF
--- a/api/v1/lib/agent/calls/calls.go
+++ b/api/v1/lib/agent/calls/calls.go
@@ -220,6 +220,22 @@ func AttachContainerInputTTY(t *mesos.TTYInfo) *agent.Call {
 	}
 }
 
+func AttachContainerInputHeartbeat(heartbeat *agent.ProcessIO_Control_Heartbeat) *agent.Call {
+	return &agent.Call{
+		Type: agent.Call_ATTACH_CONTAINER_INPUT,
+		AttachContainerInput: &agent.Call_AttachContainerInput{
+			Type: agent.Call_AttachContainerInput_PROCESS_IO,
+			ProcessIO: &agent.ProcessIO{
+				Type: agent.ProcessIO_CONTROL,
+				Control: &agent.ProcessIO_Control{
+					Type:      agent.ProcessIO_Control_HEARTBEAT,
+					Heartbeat: heartbeat,
+				},
+			},
+		},
+	}
+}
+
 func AddResourceProviderConfig(rpi mesos.ResourceProviderInfo) *agent.Call {
 	return &agent.Call{
 		Type: agent.Call_ADD_RESOURCE_PROVIDER_CONFIG,

--- a/api/v1/lib/agent/calls/calls_test.go
+++ b/api/v1/lib/agent/calls/calls_test.go
@@ -75,6 +75,7 @@ func Example() {
 		AttachContainerInput(mesos.ContainerID{}),
 		AttachContainerInputTTY(nil),
 		AttachContainerInputData(nil),
+		AttachContainerInputHeartbeat(nil),
 	)))
 
 	// Output:


### PR DESCRIPTION
This adds a helper method for sending heartbeat control messages with the `ATTACH_CONTAINER_INPUT` call.