### PR TITLE
Add a Code() method to apierrors.Error

### DIFF
--- a/api/v1/lib/httpcli/apierrors/apierrors.go
+++ b/api/v1/lib/httpcli/apierrors/apierrors.go
@@ -114,6 +114,9 @@ func (code Code) Error(details string) error {
 // Error implements error interface
 func (e *Error) Error() string { return e.message }
 
+// Code returns the error code.
+func (e *Error) Code() Code { return e.code }
+
 // Temporary returns true if the error is a temporary condition that should eventually clear.
 func (e *Error) Temporary() bool {
 	switch e.code {

--- a/api/v1/lib/httpcli/apierrors/apierrors_test.go
+++ b/api/v1/lib/httpcli/apierrors/apierrors_test.go
@@ -55,6 +55,9 @@ func TestError(t *testing.T) {
 				t.Errorf("Expected: %s, got: %s", tt.wantsMessage, err.Error())
 			}
 			apierr := err.(*Error)
+			if apierr.Code() != tt.code {
+				t.Errorf("Expected: %d, got: %d", tt.code, apierr.Code())
+			}
 			if apierr.Temporary() != tt.temporary {
 				t.Errorf("expected temporary to be %v instead of %v", tt.temporary, apierr.Temporary())
 			}


### PR DESCRIPTION
Being able to get the status code behind a Mesos error is necessary in order to fix:

https://jira.mesosphere.com/browse/DCOS_OSS-5432